### PR TITLE
✨ Feature: 카카오 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,10 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+	set('springCloudVersion', "2023.0.2")
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -40,9 +44,17 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-  
+
 	// websocket
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dev/moim/MoimApplication.java
+++ b/src/main/java/com/dev/moim/MoimApplication.java
@@ -2,9 +2,11 @@ package com.dev.moim;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
+@EnableFeignClients
 @SpringBootApplication
 public class MoimApplication {
 

--- a/src/main/java/com/dev/moim/domain/account/controller/AuthController.java
+++ b/src/main/java/com/dev/moim/domain/account/controller/AuthController.java
@@ -58,9 +58,9 @@ public class AuthController {
     @PostMapping("/oauth/kakao")
     @Operation(summary="카카오 로그인 API", description="카카오 accessToken을 이용하여 유저 정보 받아 저장하고 앱의 토큰 반환" )
     public BaseResponse<TokenResponse> kakaoSignIn(
-            @RequestBody AuthRequest request
+            @RequestBody SocialLoginRequest request
     ) {
-        return BaseResponse.onSuccess(null);
+        return BaseResponse.onSuccess(authService.kakaoLogin(request));
     }
 
     @PostMapping("/oauth/google")

--- a/src/main/java/com/dev/moim/domain/account/controller/AuthController.java
+++ b/src/main/java/com/dev/moim/domain/account/controller/AuthController.java
@@ -55,26 +55,10 @@ public class AuthController {
         return BaseResponse.onSuccess("로그아웃 성공");
     }
 
-    @PostMapping("/oauth/kakao")
-    @Operation(summary="카카오 로그인 API", description="카카오 accessToken을 이용하여 유저 정보 받아 저장하고 앱의 토큰 반환" )
-    public BaseResponse<TokenResponse> kakaoSignIn(
-            @RequestBody SocialLoginRequest request
-    ) {
-        return BaseResponse.onSuccess(null);
-    }
-
-    @PostMapping("/oauth/google")
-    @Operation(summary="구글 로그인 API", description="구글 accessToken을 이용하여 유저 정보 받아 저장하고 앱의 토큰 반환" )
-    public BaseResponse<TokenResponse> googleSignIn(
-            @RequestBody AuthRequest request
-    ) {
-        return BaseResponse.onSuccess(null);
-    }
-
-    @PostMapping("/oauth/apple")
-    @Operation(summary="애플 로그인 API", description="애플 accessToken을 이용하여 유저 정보 받아 저장하고 앱의 토큰 반환" )
-    public BaseResponse<TokenResponse> appleSignIn(
-            @RequestBody AppleAuthRequest request
+    @PostMapping("/oAuth")
+    @Operation(summary="소셜 로그인 API", description="현재는 카카오 로그인만 가능합니다." )
+    public BaseResponse<TokenResponse> oAuthLogin(
+            @RequestBody OAuthLoginRequest request
     ) {
         return BaseResponse.onSuccess(null);
     }

--- a/src/main/java/com/dev/moim/domain/account/controller/AuthController.java
+++ b/src/main/java/com/dev/moim/domain/account/controller/AuthController.java
@@ -60,7 +60,7 @@ public class AuthController {
     public BaseResponse<TokenResponse> kakaoSignIn(
             @RequestBody SocialLoginRequest request
     ) {
-        return BaseResponse.onSuccess(authService.kakaoLogin(request));
+        return BaseResponse.onSuccess(null);
     }
 
     @PostMapping("/oauth/google")

--- a/src/main/java/com/dev/moim/domain/account/dto/OAuthLoginRequest.java
+++ b/src/main/java/com/dev/moim/domain/account/dto/OAuthLoginRequest.java
@@ -1,0 +1,9 @@
+package com.dev.moim.domain.account.dto;
+
+import com.dev.moim.domain.account.entity.enums.Provider;
+
+public record OAuthLoginRequest(
+        Provider provider,
+        String oAuthToken
+) {
+}

--- a/src/main/java/com/dev/moim/domain/account/dto/SocialLoginRequest.java
+++ b/src/main/java/com/dev/moim/domain/account/dto/SocialLoginRequest.java
@@ -1,6 +1,0 @@
-package com.dev.moim.domain.account.dto;
-
-public record SocialLoginRequest(
-        String oAuthToken
-) {
-}

--- a/src/main/java/com/dev/moim/domain/account/dto/SocialLoginRequest.java
+++ b/src/main/java/com/dev/moim/domain/account/dto/SocialLoginRequest.java
@@ -1,0 +1,6 @@
+package com.dev.moim.domain.account.dto;
+
+public record SocialLoginRequest(
+        String oAuthToken
+) {
+}

--- a/src/main/java/com/dev/moim/domain/account/entity/User.java
+++ b/src/main/java/com/dev/moim/domain/account/entity/User.java
@@ -20,8 +20,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.dev.moim.domain.account.entity.enums.Role.ROLE_USER;
-
 @Entity
 @Getter
 @Builder
@@ -42,6 +40,8 @@ public class User extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private Provider provider;
+
+    private Long providerId;
 
     private LocalDateTime inactive_date;
 

--- a/src/main/java/com/dev/moim/domain/account/repository/UserRepository.java
+++ b/src/main/java/com/dev/moim/domain/account/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.dev.moim.domain.account.repository;
 
 import com.dev.moim.domain.account.entity.User;
+import com.dev.moim.domain.account.entity.enums.Provider;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -9,4 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     boolean existsByEmail(String email);
+
+    Optional<User> findByProviderIdAndProvider(Long providerId, Provider provider);
 }

--- a/src/main/java/com/dev/moim/global/common/code/status/ErrorStatus.java
+++ b/src/main/java/com/dev/moim/global/common/code/status/ErrorStatus.java
@@ -26,8 +26,10 @@ public enum ErrorStatus implements BaseErrorCode {
     // Auth 관련
     AUTH_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_001", "토큰이 만료되었습니다."),
     AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_002", "토큰이 유효하지 않습니다."),
-    INVALID_LOGIN_REQUEST(HttpStatus.UNAUTHORIZED, "AUTH_003", "올바른 이메일이나 패스워드가 아닙니다."),
-    INVALID_REQUEST_INFO(HttpStatus.UNAUTHORIZED, "AUTH_006", "카카오 정보 불러오기에 실패하였습니다."),
+    OAUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_003", "OAuth 토큰이 유효하지 않습니다."),
+    INVALID_LOGIN_REQUEST(HttpStatus.UNAUTHORIZED, "AUTH_004", "올바른 이메일이나 패스워드가 아닙니다."),
+    INVALID_REQUEST_INFO(HttpStatus.UNAUTHORIZED, "AUTH_005", "카카오 정보 불러오기에 실패하였습니다."),
+    USER_PROPERTY_NOT_FOUND(HttpStatus.BAD_REQUEST,"AUTH_006", "카카오 앱에 설정되어 있지 않은 사용자 프로퍼티를 요청하였습니다." ),
     NOT_EQUAL_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_007", "리프레시 토큰이 다릅니다."),
     NOT_CONTAIN_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_008", "해당하는 토큰이 저장되어있지 않습니다."),
     BAD_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH_009", "비밀번호를 잘못 입력했습니다."),

--- a/src/main/java/com/dev/moim/global/error/decoder/FeignErrorDecoder.java
+++ b/src/main/java/com/dev/moim/global/error/decoder/FeignErrorDecoder.java
@@ -1,0 +1,23 @@
+package com.dev.moim.global.error.decoder;
+
+import com.dev.moim.global.error.handler.AuthException;
+import feign.FeignException;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+
+import static com.dev.moim.global.common.code.status.ErrorStatus.OAUTH_INVALID_TOKEN;
+import static com.dev.moim.global.common.code.status.ErrorStatus.USER_PROPERTY_NOT_FOUND;
+
+public class FeignErrorDecoder implements ErrorDecoder {
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        if (response.status() == 400) {
+            return new AuthException(USER_PROPERTY_NOT_FOUND);
+        } else if (response.status() == 401) {
+            return new AuthException(OAUTH_INVALID_TOKEN);
+        }
+
+        return FeignException.errorStatus(methodKey, response);
+    }
+}

--- a/src/main/java/com/dev/moim/global/security/config/OAuthLoginServiceConfig.java
+++ b/src/main/java/com/dev/moim/global/security/config/OAuthLoginServiceConfig.java
@@ -1,0 +1,25 @@
+package com.dev.moim.global.security.config;
+
+import com.dev.moim.domain.account.entity.enums.Provider;
+import com.dev.moim.global.security.service.KakaoLoginService;
+import com.dev.moim.global.security.service.OAuthLoginService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.dev.moim.domain.account.entity.enums.Provider.KAKAO;
+
+@Configuration
+public class OAuthLoginServiceConfig {
+
+    @Bean
+    public Map<Provider, OAuthLoginService> oAuthLoginServiceMap(KakaoLoginService kakaoLoginService) {
+        Map<Provider, OAuthLoginService> map = new HashMap<>();
+        map.put(KAKAO, kakaoLoginService);
+        // map.put(GOOGLE, googleLoginService);
+        // map.put(APPLE, appleLoginService);
+        return map;
+    }
+}

--- a/src/main/java/com/dev/moim/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/dev/moim/global/security/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
             "/api-docs/**",
             "/api/v1/auth/join/**",
             "/api/v1/auth/reissueToken/**",
+            "/api/v1/auth/oauth/kakao/**"
     };
 
     @Bean

--- a/src/main/java/com/dev/moim/global/security/exception/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/dev/moim/global/security/exception/JwtAccessDeniedHandler.java
@@ -2,7 +2,6 @@ package com.dev.moim.global.security.exception;
 
 import com.dev.moim.global.common.BaseResponse;
 import com.dev.moim.global.security.util.HttpResponseUtil;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/com/dev/moim/global/security/exception/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/dev/moim/global/security/exception/JwtAuthenticationEntryPoint.java
@@ -2,7 +2,6 @@ package com.dev.moim.global.security.exception;
 
 import com.dev.moim.global.common.BaseResponse;
 import com.dev.moim.global.security.util.HttpResponseUtil;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/com/dev/moim/global/security/feign/config/KakaoFeignConfiguration.java
+++ b/src/main/java/com/dev/moim/global/security/feign/config/KakaoFeignConfiguration.java
@@ -1,0 +1,26 @@
+package com.dev.moim.global.security.feign.config;
+
+import com.dev.moim.global.error.decoder.FeignErrorDecoder;
+import feign.Logger;
+import feign.RequestInterceptor;
+import feign.codec.ErrorDecoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class KakaoFeignConfiguration {
+    @Bean(name = "kakaoRequestInterceptor")
+    public RequestInterceptor requestInterceptor() {
+        return template -> template.header("Content-Type", "application/x-www-form-urlencoded");
+    }
+
+    @Bean(name = "kakaoErrorDecoder")
+    public ErrorDecoder errorDecoder() {
+        return new FeignErrorDecoder();
+    }
+
+    @Bean(name = "kakaoFeignLoggerLevel")
+    Logger.Level feignLoggerLevel() {
+        return Logger.Level.FULL;
+    }
+}

--- a/src/main/java/com/dev/moim/global/security/feign/dto/KakaoUserInfo.java
+++ b/src/main/java/com/dev/moim/global/security/feign/dto/KakaoUserInfo.java
@@ -6,11 +6,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
-@AllArgsConstructor
 @Getter
-public class KakaoUserInfo {
+public class KakaoUserInfo extends OAuthUserInfo {
 
-    private Long id;
+    @JsonProperty("id")
+    private Long providerId;
 
     @JsonProperty("kakao_account")
     private KakaoAccount kakaoAccount;
@@ -39,5 +39,11 @@ public class KakaoUserInfo {
 
             private String birthday;
         }
+    }
+
+    public KakaoUserInfo(Long providerId, KakaoAccount kakaoAccount) {
+        super(providerId, kakaoAccount.getEmail(), kakaoAccount.getProfile().getNickname());
+        this.providerId = providerId;
+        this.kakaoAccount = kakaoAccount;
     }
 }

--- a/src/main/java/com/dev/moim/global/security/feign/dto/KakaoUserInfo.java
+++ b/src/main/java/com/dev/moim/global/security/feign/dto/KakaoUserInfo.java
@@ -1,0 +1,43 @@
+package com.dev.moim.global.security.feign.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class KakaoUserInfo {
+
+    private Long id;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    public static class KakaoAccount {
+        private Profile profile;
+        @JsonProperty("email_needs_agreement")
+        private boolean emailNeedsAgreement;
+        private String email;
+
+        @NoArgsConstructor
+        @AllArgsConstructor
+        @Getter
+        public static class Profile {
+            private String nickname;
+
+            @JsonProperty("thumbnail_image_url")
+            private String thumbnailImageUrl;
+
+            private String gender;
+
+            private String birthyear;
+
+            private String birthday;
+        }
+    }
+}

--- a/src/main/java/com/dev/moim/global/security/feign/dto/OAuthUserInfo.java
+++ b/src/main/java/com/dev/moim/global/security/feign/dto/OAuthUserInfo.java
@@ -1,0 +1,14 @@
+package com.dev.moim.global.security.feign.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OAuthUserInfo {
+    private Long providerId;
+    private String email;
+    private String nickname;
+}

--- a/src/main/java/com/dev/moim/global/security/feign/request/KakaoFeign.java
+++ b/src/main/java/com/dev/moim/global/security/feign/request/KakaoFeign.java
@@ -1,0 +1,19 @@
+package com.dev.moim.global.security.feign.request;
+
+import com.dev.moim.global.security.feign.config.KakaoFeignConfiguration;
+import com.dev.moim.global.security.feign.dto.KakaoUserInfo;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(
+        name = "KakaoFeign",
+        url = "https://kapi.kakao.com",
+        configuration = KakaoFeignConfiguration.class
+)
+@Component
+public interface KakaoFeign {
+    @GetMapping(value = "/v2/user/me")
+    KakaoUserInfo getUserInfo(@RequestHeader(name = "Authorization") String token);
+}

--- a/src/main/java/com/dev/moim/global/security/filter/LoginFilter.java
+++ b/src/main/java/com/dev/moim/global/security/filter/LoginFilter.java
@@ -76,7 +76,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         String accessToken = jwtUtil.createAccessToken(principalDetails);
         String refreshToken = jwtUtil.createRefreshToken(principalDetails);
 
-        refreshTokenService.saveToken(principalDetails.getEmail(), refreshToken, jwtUtil.getRefreshTokenValiditySec());
+        refreshTokenService.saveToken(principalDetails.user().getEmail(), refreshToken, jwtUtil.getRefreshTokenValiditySec());
 
         HttpResponseUtil.setSuccessResponse(response, HttpStatus.CREATED, new TokenResponse(accessToken, refreshToken));
     }

--- a/src/main/java/com/dev/moim/global/security/filter/OAuth2LoginFilter.java
+++ b/src/main/java/com/dev/moim/global/security/filter/OAuth2LoginFilter.java
@@ -1,0 +1,117 @@
+package com.dev.moim.global.security.filter;
+
+import com.dev.moim.domain.account.dto.SocialLoginRequest;
+import com.dev.moim.domain.account.dto.TokenResponse;
+import com.dev.moim.domain.account.entity.User;
+import com.dev.moim.domain.account.repository.UserRepository;
+import com.dev.moim.global.error.handler.AuthException;
+import com.dev.moim.global.redis.service.RefreshTokenService;
+import com.dev.moim.global.security.feign.dto.KakaoUserInfo;
+import com.dev.moim.global.security.feign.request.KakaoFeign;
+import com.dev.moim.global.security.principal.PrincipalDetails;
+import com.dev.moim.global.security.util.HttpResponseUtil;
+import com.dev.moim.global.security.util.JwtUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+import java.io.IOException;
+
+import static com.dev.moim.domain.account.entity.enums.Provider.KAKAO;
+import static com.dev.moim.domain.account.entity.enums.Role.ROLE_USER;
+import static com.dev.moim.global.common.code.status.ErrorStatus._BAD_REQUEST;
+
+@Slf4j
+public class OAuth2LoginFilter extends AbstractAuthenticationProcessingFilter {
+
+    private final KakaoFeign kakaoFeign;
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+    private final RefreshTokenService refreshTokenService;
+
+    public OAuth2LoginFilter(KakaoFeign kakaoFeign, UserRepository userRepository, JwtUtil jwtUtil, RefreshTokenService refreshTokenService) {
+        super(new AntPathRequestMatcher("/api/v1/auth/oauth/kakao"));
+        this.kakaoFeign = kakaoFeign;
+        this.userRepository = userRepository;
+        this.jwtUtil = jwtUtil;
+        this.refreshTokenService = refreshTokenService;
+    }
+
+    @Override
+    public Authentication attemptAuthentication(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response) throws IOException, ServletException {
+
+        log.info("** OAuth2LoginFilter **");
+
+        SocialLoginRequest socialLoginRequest = readBody(request);
+
+        log.info("oAuthToken = {}", socialLoginRequest.oAuthToken());
+
+        KakaoUserInfo kakaoUserInfo = kakaoFeign.getUserInfo("Bearer " + socialLoginRequest.oAuthToken());
+
+        User user = userRepository.findByProviderIdAndProvider(kakaoUserInfo.getId(), KAKAO)
+                .orElseGet(() -> createNewKakaoUser(kakaoUserInfo));
+
+        PrincipalDetails principalDetails = new PrincipalDetails(user);
+
+        String accessToken = jwtUtil.createAccessToken(principalDetails);
+        String refreshToken = jwtUtil.createRefreshToken(principalDetails);
+
+        refreshTokenService.saveToken(principalDetails.user().getEmail(), refreshToken, jwtUtil.getRefreshTokenValiditySec());
+
+        HttpResponseUtil.setSuccessResponse(response, HttpStatus.CREATED, new TokenResponse(accessToken, refreshToken));
+
+        return null;
+    }
+
+    private SocialLoginRequest readBody(HttpServletRequest request) {
+        SocialLoginRequest requestDTO = null;
+        ObjectMapper om = new ObjectMapper();
+
+        try {
+            requestDTO = om.readValue(request.getInputStream(), SocialLoginRequest.class);
+        } catch (IOException e) {
+            throw new AuthException(_BAD_REQUEST);
+        }
+
+        return requestDTO;
+    }
+
+    private User createNewKakaoUser(KakaoUserInfo kakaoUserInfo) {
+        User user = User.builder()
+                .email(kakaoUserInfo.getKakaoAccount().getEmail())
+                .nickname(kakaoUserInfo.getKakaoAccount().getProfile().getNickname())
+                .role(ROLE_USER)
+                .provider(KAKAO)
+                .build();
+        return userRepository.save(user);
+    }
+
+    @Override
+    protected void successfulAuthentication(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain chain,
+            @NonNull Authentication authResult) throws IOException, ServletException {
+        SecurityContextHolder.getContext().setAuthentication(authResult);
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException failed) throws IOException, ServletException {
+        HttpResponseUtil.setErrorResponse(response, HttpStatus.UNAUTHORIZED, "Authentication failed");
+    }
+}

--- a/src/main/java/com/dev/moim/global/security/principal/PrincipalDetails.java
+++ b/src/main/java/com/dev/moim/global/security/principal/PrincipalDetails.java
@@ -1,7 +1,6 @@
 package com.dev.moim.global.security.principal;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import com.dev.moim.domain.account.entity.User;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -9,38 +8,43 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.ArrayList;
 import java.util.Collection;
 
-@Getter
-@RequiredArgsConstructor
-public class PrincipalDetails implements UserDetails {
-
-    private final Long id;
-    private final String email;
-    private final String password;
-    private final String authority;
+public record PrincipalDetails(User user) implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         Collection<GrantedAuthority> collections = new ArrayList<>();
-        collections.add(new SimpleGrantedAuthority(authority));
+        collections.add(new SimpleGrantedAuthority(user.getRole().toString()));
 
         return collections;
     }
 
     @Override
-    public String getUsername() {return this.email;}
+    public String getUsername() {
+        return user.getEmail();
+    }
 
     @Override
-    public String getPassword() {return this.password;}
+    public String getPassword() {
+        return user.getPassword();
+    }
 
     @Override
-    public boolean isAccountNonExpired() {return true;}
+    public boolean isAccountNonExpired() {
+        return true;
+    }
 
     @Override
-    public boolean isAccountNonLocked() {return true;}
+    public boolean isAccountNonLocked() {
+        return true;
+    }
 
     @Override
-    public boolean isCredentialsNonExpired() {return true;}
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
 
     @Override
-    public boolean isEnabled() {return true;}
+    public boolean isEnabled() {
+        return true;
+    }
 }

--- a/src/main/java/com/dev/moim/global/security/principal/PrincipalDetailsService.java
+++ b/src/main/java/com/dev/moim/global/security/principal/PrincipalDetailsService.java
@@ -21,6 +21,6 @@ public class PrincipalDetailsService implements UserDetailsService {
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new AuthException(USER_NOT_FOUND));
-        return new PrincipalDetails(user.getId(), user.getEmail(), user.getPassword(), user.getRole().toString());
+        return new PrincipalDetails(user);
     }
 }

--- a/src/main/java/com/dev/moim/global/security/service/KakaoLoginService.java
+++ b/src/main/java/com/dev/moim/global/security/service/KakaoLoginService.java
@@ -1,0 +1,45 @@
+package com.dev.moim.global.security.service;
+
+import com.dev.moim.domain.account.entity.User;
+import com.dev.moim.domain.account.repository.UserRepository;
+import com.dev.moim.global.security.feign.dto.KakaoUserInfo;
+import com.dev.moim.global.security.feign.dto.OAuthUserInfo;
+import com.dev.moim.global.security.feign.request.KakaoFeign;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import static com.dev.moim.domain.account.entity.enums.Provider.KAKAO;
+import static com.dev.moim.domain.account.entity.enums.Role.ROLE_USER;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoLoginService implements OAuthLoginService {
+
+    private final KakaoFeign kakaoFeign;
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuthUserInfo getUserInfo(String oAuthToken) {
+        return kakaoFeign.getUserInfo("Bearer " + oAuthToken);
+    }
+
+    @Override
+    public User findOrCreateUser(OAuthUserInfo oAuthUserInfo) {
+        KakaoUserInfo kakaoUserInfo = (KakaoUserInfo) oAuthUserInfo;
+
+        log.info("[KAKAO] providerId = {}", kakaoUserInfo.getProviderId());
+
+        User user = userRepository.findByProviderIdAndProvider(kakaoUserInfo.getProviderId(), KAKAO)
+                .orElseGet(() -> User.builder()
+                        .email(kakaoUserInfo.getKakaoAccount().getEmail())
+                        .nickname(kakaoUserInfo.getKakaoAccount().getProfile().getNickname())
+                        .role(ROLE_USER)
+                        .provider(KAKAO)
+                        .providerId((kakaoUserInfo.getProviderId()))
+                        .build());
+
+        return userRepository.save(user);
+    }
+}

--- a/src/main/java/com/dev/moim/global/security/service/OAuthLoginService.java
+++ b/src/main/java/com/dev/moim/global/security/service/OAuthLoginService.java
@@ -1,0 +1,10 @@
+package com.dev.moim.global.security.service;
+
+import com.dev.moim.domain.account.entity.User;
+import com.dev.moim.global.security.feign.dto.OAuthUserInfo;
+
+public interface OAuthLoginService {
+    OAuthUserInfo getUserInfo(String oAuthToken);
+
+    User findOrCreateUser(OAuthUserInfo oAuthUserInfo);
+}

--- a/src/main/java/com/dev/moim/global/security/util/JwtUtil.java
+++ b/src/main/java/com/dev/moim/global/security/util/JwtUtil.java
@@ -47,7 +47,7 @@ public class JwtUtil {
         Instant expirationTime = issuedAt.plusSeconds(validitySeconds);
 
         return Jwts.builder()
-                .setSubject(principalDetails.getId().toString())
+                .setSubject(principalDetails.user().getId().toString())
                 .claim("email", principalDetails.getUsername())
                 .claim("role", principalDetails.getAuthorities())
                 .setIssuedAt(Date.from(issuedAt))


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #24 

## 📌 개요
- 카카오 로그인 구현

## 🔁 변경 사항
✔ 8a4b43e23a25a486e3f80380b7b5d4797a116dd6 : service 단에 구현

✔ 00d8567fff1e87c84764055348917d23bd21410a : filter 단에 구현

✔ 7424b6175aa44d80df2e05f1c0e8d6eaf281cc30 : 소셜 로그인 필터 확장 가능하도록 리팩토링
- 카카오 로그인만 구현한 상태이며, 추후 구글, 애플 소셜 로그인을 추가할 예정이므로 확장 가능하도록 리팩토링 했습니다.

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
**소셜 로그인 구현에서, 프론트와 백엔드의 책임 분배**
- 현재 로직에선, 카카오 서버로부터 인증 코드와 토큰을 프론트가 받는 로직으로 구현했습니다. 해당 토큰을 카카오 서버에 보내서 유저 정보를 받아오고 moim 자체 accessToken 과 refreshToken을 생성해서 응답으로 보냅니다.
- 로그인에 성공하면 JWT를 발급해야 하는 문제로, 코드 발급 동작 방식의 책임을 프론트와 백엔드 어느쪽에 둘지 프론트 측과 추가적인 의논 후 로직을 변경할 예정입니다.

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
