### PR TITLE
🐛 Fix: 회원가입 시 유저 계정 중복 검증 로직 수정

### DIFF
--- a/src/main/java/com/dev/moim/domain/account/repository/UserRepository.java
+++ b/src/main/java/com/dev/moim/domain/account/repository/UserRepository.java
@@ -9,7 +9,9 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmailAndProvider(String email, Provider provider);
 
-    boolean existsByEmailAndProvider(String email, Provider provider);
-
     Optional<User> findByProviderIdAndProvider(String providerId, Provider provider);
+
+    boolean existsByEmail(String email);
+
+    boolean existsByProviderAndProviderId(Provider provider, String providerId);
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #61 

## 📌 개요
- 회원가입 시 유저 계정 중복 검증 로직 수정

## 🔁 변경 사항
✔️ 0635bf253125b0016700a7d973fd63fbaf5daa66 : 회원가입 시 유저 계정 중복 검증 로직 수정
- 소셜 로그인 도입 이전엔 이메일 인증을 통해 이메일 유효성을 검증하고, 중복된 이메일로 회원가입이 불가능하게 로직을 구현했기 때문에 이메일로 유저 구분이 가능했습니다. 소셜 로그인을 도입하게 되면서 여러 소셜에서 중복된 이메일을 사용하는 유저도 있고, 애플의 경우 계정 이메일을 변경할 수 있기 때문에 이메일로 유저를 구분할 수 없게 되었습니다.
- 소셜 로그인 유저의 경우 해당 서버로 부터 유저의 일부 정보를 받아올 수 있습니다. 하지만 저희 서비스를 이용하기 위해서 추가로 필요한 정보가 있으며 인증 서버마다 제공하는 정보의 범위가 다르기 때문에 추가적인 입력 절차가 필요합니다. 이 지점에서, 등록되지 않은 유저인 경우 바로 회원가입 성공 및 로그인 시키고 추후 해당 정보가 필요할 때 입력하도록 유도할지, 바로 회원가입 성공 및 로그인 처리하지 않고 추가 정보를 입력 받은 후 신규 회원으로 등록할지 논의를 하게 되었습니다. 저희가 제공하는 서비스를 고려했을 때, 필수적으로 필요한 정보들이라고 판단하였고 등록되지 않은 유저의 경우 추가 정보를 입력하는 절차로 유도한 후, 필요한 정보가 모두 넘어온 경우 회원으로 등록하도록 기획을 확정했습니다.
- 일반 로그인 유저, 소셜 로그인 유저가 같은 회원가입 API로 요청하도록 구현하게 되면서, provider에 따라 다른 중복 검증을 하도록 수정했습니다.

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
- 일반 로그인 유저의 경우 providerId를 입력받지 않고, 소셜 로그인 유저의 경우 비밀번호를 입력받지 않는데 join API을 따로 두는게 좋은 설계일지 고민 중입니다.
- 비밀번호 유효성 검증 로직도 추가할 예정입니다.

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
