### PR TITLE
✨ Feat: 회원가입 DTO 검증 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,8 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 dependencyManagement {

--- a/src/main/java/com/dev/moim/domain/account/controller/AuthController.java
+++ b/src/main/java/com/dev/moim/domain/account/controller/AuthController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,12 +22,12 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/join")
-    @Operation(summary="회원 가입 API", description="로그인 타입을 입력해주세요. \n [Provider] LOCAL(일반 로그인), KAKAO, APPLE, GOOGLE, NAVER" )
+    @Operation(summary="회원 가입 API", description="회원가입 API 입니다." )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON201", description = "요청 성공 및 리소스 생성됨"),
             @ApiResponse(responseCode = "AUTH_011", description = "이미 가입한 메일 입니다.")
     })
-    public BaseResponse<TokenResponse> join(@RequestBody JoinRequest request) {
+    public BaseResponse<TokenResponse> join(@Valid @RequestBody JoinRequest request) {
         return BaseResponse.onSuccess(authService.join(request));
     }
 
@@ -38,7 +39,7 @@ public class AuthController {
             @ApiResponse(responseCode = "AUTH_010", description = "인증에 실패했습니다."),
             @ApiResponse(responseCode = "AUTH_021", description = "존재하지 않는 사용자입니다.")
     })
-    public BaseResponse<TokenResponse> login(@RequestBody LoginRequest request) {
+    public BaseResponse<TokenResponse> localLogin(@RequestBody LoginRequest request) {
         return BaseResponse.onSuccess(null);
     }
 

--- a/src/main/java/com/dev/moim/domain/account/dto/JoinRequest.java
+++ b/src/main/java/com/dev/moim/domain/account/dto/JoinRequest.java
@@ -2,20 +2,27 @@ package com.dev.moim.domain.account.dto;
 
 import com.dev.moim.domain.account.entity.enums.Gender;
 import com.dev.moim.domain.account.entity.enums.Provider;
+import com.dev.moim.domain.account.entity.enums.Role;
+import com.dev.moim.global.validation.annotation.LocalAccountValidation;
+import com.dev.moim.global.validation.annotation.PasswordValidation;
+import com.dev.moim.global.validation.annotation.OAuthAccountValidation;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.lang.NonNull;
 
+@OAuthAccountValidation
+@LocalAccountValidation
+@PasswordValidation
 public record JoinRequest(
         @Schema(description = "로그인 타입", defaultValue = "KAKAO", allowableValues = {"LOCAL", "KAKAO", "APPLE", "GOOGLE"})
-        Provider provider,
+        @NonNull Provider provider,
         String providerId,
-        String nickname,
-        String email,
+        @NotBlank String nickname,
+        @NotBlank String email,
         String password,
-        @Schema(description = "유저 role", defaultValue = "ROLE_USER", allowableValues = {"ROLE_USER", "ROLE_ADMIN"})
-        String role,
         @Schema(description = "성별", defaultValue = "FEMALE", allowableValues = {"FEMALE", "MALE"})
-        Gender gender,
-        String birth,
-        String residence
+        @NonNull Gender gender,
+        @NotBlank String birth,
+        @NotBlank String residence
 ) {
 }

--- a/src/main/java/com/dev/moim/domain/account/service/AuthService.java
+++ b/src/main/java/com/dev/moim/domain/account/service/AuthService.java
@@ -40,23 +40,13 @@ public class AuthService {
     @Transactional
     public TokenResponse join(JoinRequest request) {
 
-        validateEmailDuplication(request.provider(), request.providerId(), request.email());
-
-        Role role = Optional.ofNullable(request.role())
-                .filter(requestRole -> ! requestRole.isEmpty())
-                .map(Role::valueOf)
-                .orElse(ROLE_USER);
-
-        Provider provider = Optional.ofNullable(request.provider())
-                .orElseThrow(() -> new AuthException(PROVIDER_NOT_FOUND));
-
         User user = User.builder()
+                .provider(request.provider())
+                .providerId(request.providerId())
                 .nickname(request.nickname())
                 .email(request.email())
                 .password(passwordEncoder.encode(request.password()))
-                .role(role)
-                .provider(provider)
-                .providerId(request.providerId())
+                .role(ROLE_USER)
                 .userProfileList(new ArrayList<>())
                 .build();
 
@@ -77,17 +67,7 @@ public class AuthService {
 
         redisUtil.setValue(principalDetails.user().getId().toString(), refreshToken, jwtUtil.getRefreshTokenValiditySec());
 
-        return new TokenResponse(accessToken, refreshToken, provider);
-    }
-
-    private void validateEmailDuplication(Provider provider, String providerId, String email) {
-        boolean isDuplicated = (provider == Provider.LOCAL)
-                ? userRepository.existsByEmail(email)
-                : userRepository.existsByProviderAndProviderId(provider, providerId);
-
-        if (isDuplicated) {
-            throw new AuthException(EMAIL_DUPLICATION);
-        }
+        return new TokenResponse(accessToken, refreshToken, request.provider());
     }
 
     @Transactional

--- a/src/main/java/com/dev/moim/domain/account/service/AuthService.java
+++ b/src/main/java/com/dev/moim/domain/account/service/AuthService.java
@@ -40,12 +40,16 @@ public class AuthService {
     @Transactional
     public TokenResponse join(JoinRequest request) {
 
+        String encodedPassword = (request.provider() == Provider.LOCAL && request.password() != null)
+                ? passwordEncoder.encode(request.password())
+                : null;
+
         User user = User.builder()
                 .provider(request.provider())
                 .providerId(request.providerId())
                 .nickname(request.nickname())
                 .email(request.email())
-                .password(passwordEncoder.encode(request.password()))
+                .password(encodedPassword)
                 .role(ROLE_USER)
                 .userProfileList(new ArrayList<>())
                 .build();

--- a/src/main/java/com/dev/moim/global/common/code/status/ErrorStatus.java
+++ b/src/main/java/com/dev/moim/global/common/code/status/ErrorStatus.java
@@ -39,10 +39,12 @@ public enum ErrorStatus implements BaseErrorCode {
     USER_INSUFFICIENT_PERMISSION(HttpStatus.FORBIDDEN, "AUTH_014", "권한이 부족한 사용자 입니다."),
     MISSING_AUTHORIZATION_HEADER(HttpStatus.UNAUTHORIZED, "AUTH_015", "Authorization 헤더가 비어있습니다."),
     PROVIDER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_016", "지원하지 않는 로그인 provider 입니다."),
-    ID_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_018", "만료된 ID 토큰 입니다."),
-    ID_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "AUTH_019", "유효하지 않은 ID 토큰 입니다."),
-    LOGOUT_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_020", "로그아웃된 access 토큰 입니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_021", "존재하지 않는 사용자입니다."),
+    ID_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_017", "만료된 ID 토큰 입니다."),
+    ID_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "AUTH_018", "유효하지 않은 ID 토큰 입니다."),
+    LOGOUT_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_019", "로그아웃된 access 토큰 입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_020", "존재하지 않는 사용자입니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "AUTH_021", "비밀번호 조건에 맞지 않습니다."),
+    OAUTH_ACCOUNT_DUPLICATION(HttpStatus.BAD_REQUEST, "AUTH_022", "이미 가입한 소셜 계정입니다."),
 
     // Email 관련
     EMAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "EMAIL_001", "이메일 전송에 실패했습니다."),

--- a/src/main/java/com/dev/moim/global/validation/annotation/LocalAccountValidation.java
+++ b/src/main/java/com/dev/moim/global/validation/annotation/LocalAccountValidation.java
@@ -1,0 +1,17 @@
+package com.dev.moim.global.validation.annotation;
+
+import com.dev.moim.global.validation.validator.LocalAccountValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = LocalAccountValidator.class)
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LocalAccountValidation {
+    String message() default "이미 가입된 메일입니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/dev/moim/global/validation/annotation/OAuthAccountValidation.java
+++ b/src/main/java/com/dev/moim/global/validation/annotation/OAuthAccountValidation.java
@@ -1,0 +1,17 @@
+package com.dev.moim.global.validation.annotation;
+
+import com.dev.moim.global.validation.validator.OAuthAccountValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = OAuthAccountValidator.class)
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OAuthAccountValidation {
+    String message() default "이미 가입된 소셜 계정입니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/dev/moim/global/validation/annotation/PasswordValidation.java
+++ b/src/main/java/com/dev/moim/global/validation/annotation/PasswordValidation.java
@@ -1,0 +1,17 @@
+package com.dev.moim.global.validation.annotation;
+
+import com.dev.moim.global.validation.validator.PasswordValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = PasswordValidator.class)
+@Target( {ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PasswordValidation {
+    String message() default "비밀번호 조건에 맞지 않습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/dev/moim/global/validation/validator/LocalAccountValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/LocalAccountValidator.java
@@ -1,0 +1,43 @@
+package com.dev.moim.global.validation.validator;
+
+import com.dev.moim.domain.account.dto.JoinRequest;
+import com.dev.moim.domain.account.repository.UserRepository;
+import com.dev.moim.global.validation.annotation.LocalAccountValidation;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import static com.dev.moim.domain.account.entity.enums.Provider.LOCAL;
+import static com.dev.moim.global.common.code.status.ErrorStatus.EMAIL_DUPLICATION;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LocalAccountValidator implements ConstraintValidator<LocalAccountValidation, JoinRequest> {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public void initialize(LocalAccountValidation constraintAnnotation) {}
+
+    @Override
+    public boolean isValid(JoinRequest request, ConstraintValidatorContext context) {
+
+        if (request.provider() != LOCAL) return true;
+
+        boolean isDuplicated = userRepository.existsByEmail(request.email());
+
+        if (isDuplicated) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(EMAIL_DUPLICATION.getMessage())
+                    .addPropertyNode("email")
+                    .addConstraintViolation();
+
+            log.warn("이미 가입된 메일입니다.");
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/dev/moim/global/validation/validator/OAuthAccountValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/OAuthAccountValidator.java
@@ -1,0 +1,43 @@
+package com.dev.moim.global.validation.validator;
+
+import com.dev.moim.domain.account.dto.JoinRequest;
+import com.dev.moim.domain.account.repository.UserRepository;
+import com.dev.moim.global.validation.annotation.OAuthAccountValidation;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import static com.dev.moim.domain.account.entity.enums.Provider.LOCAL;
+import static com.dev.moim.global.common.code.status.ErrorStatus.OAUTH_ACCOUNT_DUPLICATION;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuthAccountValidator implements ConstraintValidator<OAuthAccountValidation, JoinRequest> {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public void initialize(OAuthAccountValidation constraintAnnotation) {}
+
+    @Override
+    public boolean isValid(JoinRequest request, ConstraintValidatorContext context) {
+
+        if (request.provider() == LOCAL) return true;
+
+        boolean isDuplicated = userRepository.existsByProviderAndProviderId(request.provider(), request.providerId());
+
+        if (isDuplicated) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(OAUTH_ACCOUNT_DUPLICATION.getMessage())
+                    .addPropertyNode("providerId")
+                    .addConstraintViolation();
+
+            log.warn("이미 가입된 소셜 계정입니다.");
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/dev/moim/global/validation/validator/PasswordValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/PasswordValidator.java
@@ -1,0 +1,43 @@
+package com.dev.moim.global.validation.validator;
+
+import com.dev.moim.domain.account.dto.JoinRequest;
+import com.dev.moim.global.validation.annotation.PasswordValidation;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import static com.dev.moim.domain.account.entity.enums.Provider.LOCAL;
+import static com.dev.moim.global.common.code.status.ErrorStatus.INVALID_PASSWORD;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PasswordValidator implements ConstraintValidator<PasswordValidation, JoinRequest> {
+
+    @Override
+    public void initialize(PasswordValidation constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(JoinRequest request, ConstraintValidatorContext context) {
+
+        log.info("PasswordValidator");
+
+        if (request.provider() == LOCAL) {
+            String passwordPattern = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[\\W_]).{8,16}$";
+            if (request.password() == null || !request.password().matches(passwordPattern)) {
+                context.disableDefaultConstraintViolation();
+                context.buildConstraintViolationWithTemplate(INVALID_PASSWORD.getMessage())
+                        .addPropertyNode("password")
+                        .addConstraintViolation();
+
+                log.warn("비밀번호 조건에 맞지 않습니다.");
+                return false;
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #63 

## 📌 개요
**- 회원가입 DTO 검증 로직 구현**

소셜 로그인을 시도한 유저 또한 등록되지 않은 유저인 경우, 유저로부터 추가 정보를 받기 위해 회원가입 절차를 진행하도록 회원가입 플로우를 정했습니다. 이에 따라 일반 로그인 유저, 소셜 로그인 유저의 회원가입 API를 하나로 둘지 또는 각각 구현할지 고민하게 되었고, 프론트 회원가입 로직을 고려했을 때 하나의 API로 두는게 더 좋은 설계라고 판단했습니다. 하나의 join API로 구현하다보니 로그인 타입에 따라 다른 조건을 적용해야하는 케이스가 생겼습니다. 

- 유저 정보 중 password, providerId는 로그인 타입에 따라 유무가 달라지는데, 비밀번호 조건 만족 여부 검증, 이미 가입된 유저인지 검증하는 로직에서 각각 사용됨
- 회원가입을 요청한 유저가 이미 등록된 회원인지 판단하는 로직이 로그인 타입에 따라 달라짐

회원가입 과정에서의 이러한 검증 로직에서 로그인 타입에 따라 케이스를 나누어 구현하게 되면서 로직이 복잡해지게 되었고, 이를 해결하기 위한 방법을 찾던 중 커스텀 어노테이션을 활용하게 되었습니다.

## 🔁 변경 사항
**✔️ 38b6783a4e7f8c525b4be9619b724e2b96d48c94 : 회원가입 DTO 검증 로직 구현**
- 비밀번호 조건 만족 여부 검증하는 커스텀 어노테이션
- (일반 로그인 타입 회원가입 요청 유저) 이미 가입된 메일로 회원가입을 시도하는지 확인하는 커스텀 어노테이션
- (소셜 로그인 타입 회원가입 요청 유저) 이미 가입된 소셜 계정인지 확인하는 커스텀 어노테이션

이렇게 3개의 커스텀 어노테이션을 구현했고, 회원가입 DTO인 JoinRequest에 커스텀 어노테이션을 적용해서 필요한 검증 절차를 거친 후 service단에 진입하도록 수정했습니다.

**✔️ 7b9e950dc74eff2278535cd078ac928e9a08c3bb : 커스텀 예외 처리 로직 구현**
- 요청 body에 null 있는 경우, 응답 통일을 위해 만든 BaseResponse가 아닌 기본 형태 응답으로 응답이 생성됐습니다. null이 있는 경우, HttpMessageNotReadableException 예외가 발생하게 되는데 ResponseEntityExceptionHandler를 확인해본 결과 HTTP 메시지가 올바르지 않을 때 발생하는 예외(JSON 문법 오류, 필수 필드 누락)를 handleHttpMessageNotReadable 메서드가 처리하고 있었고, 따라서 기본 형태 응답으로 생성되고 있었음을 확인할 수 있었습니다.
- ExceptionAdvice에서 handleHttpMessageNotReadable를 커스텀해서 BaseResponse를 생성하도록 구현했습니다.

**✔️ beb3ee423f19a3b521d88505c98bf8f24820f623 : 비밀번호 인코딩 조건 설정**

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
- 회의에서 언급했던대로 DTO명 "-DTO"로 통일하도록 하겠습니다!

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
