### PR TITLE
✨ Feature: 유저 인증 관련 예외 처리

### DIFF
--- a/src/main/java/com/dev/moim/domain/account/dto/JoinRequest.java
+++ b/src/main/java/com/dev/moim/domain/account/dto/JoinRequest.java
@@ -2,7 +2,6 @@ package com.dev.moim.domain.account.dto;
 
 import com.dev.moim.domain.account.entity.enums.Gender;
 import com.dev.moim.domain.account.entity.enums.Provider;
-import com.dev.moim.domain.account.entity.enums.Role;
 import com.dev.moim.global.validation.annotation.LocalAccountValidation;
 import com.dev.moim.global.validation.annotation.PasswordValidation;
 import com.dev.moim.global.validation.annotation.OAuthAccountValidation;

--- a/src/main/java/com/dev/moim/global/common/code/status/ErrorStatus.java
+++ b/src/main/java/com/dev/moim/global/common/code/status/ErrorStatus.java
@@ -35,11 +35,11 @@ public enum ErrorStatus implements BaseErrorCode {
     AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "AUTH_010", "인증에 실패했습니다."),
     EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST, "AUTH_011", "이미 가입한 메일 입니다."),
     INVALID_GENDER(HttpStatus.BAD_REQUEST, "AUTH_012", "올바르지 않은 gender 입력값 입니다."),
-    USER_AUTHENTICATION_REQUIRED(HttpStatus.UNAUTHORIZED, "AUTH_013", "인증이 필요한 사용자입니다."),
+    USER_AUTHENTICATION_FAIL(HttpStatus.UNAUTHORIZED, "AUTH_013", "유저 인증에 실패했습니다."),
     USER_INSUFFICIENT_PERMISSION(HttpStatus.FORBIDDEN, "AUTH_014", "권한이 부족한 사용자 입니다."),
     MISSING_AUTHORIZATION_HEADER(HttpStatus.UNAUTHORIZED, "AUTH_015", "Authorization 헤더가 비어있습니다."),
     PROVIDER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_016", "지원하지 않는 로그인 provider 입니다."),
-    ID_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_017", "만료된 ID 토큰 입니다."),
+    ID_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_017", "ID 토큰이 만료되었습니다."),
     ID_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "AUTH_018", "유효하지 않은 ID 토큰 입니다."),
     LOGOUT_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_019", "로그아웃된 access 토큰 입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_020", "존재하지 않는 사용자입니다."),
@@ -48,6 +48,8 @@ public enum ErrorStatus implements BaseErrorCode {
     OAUTH_SECRET_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH_023", "OAuth 관련 환경 변수가 누락되었습니다."),
     GET_OAUTH_USER_INFO_FAIL(HttpStatus.BAD_REQUEST, "AUTH_024", "OAuth 유저 정보 요청에 실패했습니다."),
     PROVIDER_ID_NOT_FOUND(HttpStatus.BAD_REQUEST, "AUTH_025", "providerId가 누락되었습니다."),
+    INVALID_REQUEST_BODY(HttpStatus.BAD_REQUEST, "AUTH_026", "잘못된 요청 본문입니다."),
+    INVALID_REQUEST_HEADER(HttpStatus.BAD_REQUEST, "AUTH_027", "잘못된 요청 헤더입니다."),
 
     // Email 관련
     EMAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "EMAIL_001", "이메일 전송에 실패했습니다."),

--- a/src/main/java/com/dev/moim/global/common/code/status/ErrorStatus.java
+++ b/src/main/java/com/dev/moim/global/common/code/status/ErrorStatus.java
@@ -45,6 +45,9 @@ public enum ErrorStatus implements BaseErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_020", "존재하지 않는 사용자입니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "AUTH_021", "비밀번호 조건에 맞지 않습니다."),
     OAUTH_ACCOUNT_DUPLICATION(HttpStatus.BAD_REQUEST, "AUTH_022", "이미 가입한 소셜 계정입니다."),
+    OAUTH_SECRET_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH_023", "OAuth 관련 환경 변수가 누락되었습니다."),
+    GET_OAUTH_USER_INFO_FAIL(HttpStatus.BAD_REQUEST, "AUTH_024", "OAuth 유저 정보 요청에 실패했습니다."),
+    PROVIDER_ID_NOT_FOUND(HttpStatus.BAD_REQUEST, "AUTH_025", "providerId가 누락되었습니다."),
 
     // Email 관련
     EMAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "EMAIL_001", "이메일 전송에 실패했습니다."),

--- a/src/main/java/com/dev/moim/global/common/code/status/ErrorStatus.java
+++ b/src/main/java/com/dev/moim/global/common/code/status/ErrorStatus.java
@@ -50,6 +50,7 @@ public enum ErrorStatus implements BaseErrorCode {
     PROVIDER_ID_NOT_FOUND(HttpStatus.BAD_REQUEST, "AUTH_025", "providerId가 누락되었습니다."),
     INVALID_REQUEST_BODY(HttpStatus.BAD_REQUEST, "AUTH_026", "잘못된 요청 본문입니다."),
     INVALID_REQUEST_HEADER(HttpStatus.BAD_REQUEST, "AUTH_027", "잘못된 요청 헤더입니다."),
+    USER_UNREGISTERED(HttpStatus.UNAUTHORIZED, "AUTH_028", "존재하지 않는 계정입니다. 회원가입을 진행해주세요."),
 
     // Email 관련
     EMAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "EMAIL_001", "이메일 전송에 실패했습니다."),

--- a/src/main/java/com/dev/moim/global/error/handler/FeignException.java
+++ b/src/main/java/com/dev/moim/global/error/handler/FeignException.java
@@ -3,6 +3,6 @@ package com.dev.moim.global.error.handler;
 import com.dev.moim.global.common.code.status.ErrorStatus;
 import com.dev.moim.global.error.GeneralException;
 
-public class AuthException extends GeneralException {
-    public AuthException(ErrorStatus errorStatus) {super(errorStatus);}
+public class FeignException extends GeneralException {
+    public FeignException(ErrorStatus errorStatus) {super(errorStatus);}
 }

--- a/src/main/java/com/dev/moim/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/dev/moim/global/security/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.dev.moim.global.config.CorsConfig;
 import com.dev.moim.global.security.exception.JwtAccessDeniedHandler;
 import com.dev.moim.global.security.exception.JwtAuthenticationEntryPoint;
 import com.dev.moim.global.security.filter.*;
+import com.dev.moim.global.security.principal.PrincipalDetailsService;
 import com.dev.moim.global.security.service.NaverLoginService;
 import com.dev.moim.global.security.service.OIDCService;
 import com.dev.moim.global.security.util.HttpResponseUtil;
@@ -18,9 +19,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -40,6 +41,7 @@ public class SecurityConfig {
     private final OIDCService oidcService;
     private final NaverLoginService naverLoginService;
     private final AuthenticationConfiguration authenticationConfiguration;
+    private final PrincipalDetailsService principalDetailsService;
 
     @Bean
     public AuthenticationManager authenticationManager() throws Exception {
@@ -50,10 +52,19 @@ public class SecurityConfig {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+        authenticationManager.getProviders().add(daoAuthenticationProvider());
         authenticationManager.getProviders().add(oidcAuthenticationProvider());
         authenticationManager.getProviders().add(naverLoginAuthenticationProvider());
 
         return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    public DaoAuthenticationProvider daoAuthenticationProvider() {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(principalDetailsService);
+        provider.setPasswordEncoder(passwordEncoder());
+        provider.setHideUserNotFoundExceptions(false);
+        return provider;
     }
 
     public OIDCAuthenticationProvider oidcAuthenticationProvider() {

--- a/src/main/java/com/dev/moim/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/dev/moim/global/security/config/SecurityConfig.java
@@ -64,7 +64,7 @@ public class SecurityConfig {
         return new NaverLoginAuthenticationProvider(naverLoginService);
     }
 
-    private final String[] allowUrls = {
+    private static final String[] allowUrls = {
             "/swagger-ui/**",
             "/v3/**",
             "/api-docs/**",
@@ -107,8 +107,8 @@ public class SecurityConfig {
 
         http.addFilterAt(customLoginFilter, UsernamePasswordAuthenticationFilter.class);
         http.addFilterAt(oAuthLoginFilter, UsernamePasswordAuthenticationFilter.class);
-        http.addFilterBefore(new JwtFilter(jwtUtil,redisUtil), CustomLoginFilter.class);
-        http.addFilterBefore(new JwtExceptionFilter(), JwtFilter.class);
+        http.addFilterBefore(new JwtFilter(jwtUtil,redisUtil, allowUrls), CustomLoginFilter.class);
+        http.addFilterBefore(new JwtExceptionFilter(allowUrls), JwtFilter.class);
 
         http.logout(logout -> logout
                 .logoutUrl("/api/v1/auth/logout")

--- a/src/main/java/com/dev/moim/global/security/exception/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/dev/moim/global/security/exception/JwtAccessDeniedHandler.java
@@ -5,6 +5,7 @@ import com.dev.moim.global.security.util.HttpResponseUtil;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
@@ -14,6 +15,7 @@ import java.io.IOException;
 
 import static com.dev.moim.global.common.code.status.ErrorStatus.USER_INSUFFICIENT_PERMISSION;
 
+@Slf4j
 @Component
 public class JwtAccessDeniedHandler implements AccessDeniedHandler {
 

--- a/src/main/java/com/dev/moim/global/security/exception/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/dev/moim/global/security/exception/JwtAuthenticationEntryPoint.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
-import static com.dev.moim.global.common.code.status.ErrorStatus.USER_AUTHENTICATION_REQUIRED;
+import static com.dev.moim.global.common.code.status.ErrorStatus.USER_AUTHENTICATION_FAIL;
 
 @Slf4j
 @Component
@@ -24,11 +24,12 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
             HttpServletRequest request,
             HttpServletResponse response,
             AuthenticationException authException) throws IOException, ServletException {
-        log.info("**JwtAuthenticationEntryPoint**");
+
+        log.error("** JwtAuthenticationEntryPoint **");
 
         BaseResponse<Object> errorResponse = BaseResponse.onFailure(
-                USER_AUTHENTICATION_REQUIRED.getCode(),
-                USER_AUTHENTICATION_REQUIRED.getMessage(),
+                USER_AUTHENTICATION_FAIL.getCode(),
+                USER_AUTHENTICATION_FAIL.getMessage(),
                 null);
 
         HttpResponseUtil.setErrorResponse(response, HttpStatus.UNAUTHORIZED, errorResponse);

--- a/src/main/java/com/dev/moim/global/security/feign/config/OauthProperties.java
+++ b/src/main/java/com/dev/moim/global/security/feign/config/OauthProperties.java
@@ -48,7 +48,7 @@ public class OauthProperties {
     private OAuthSecret getOAuthSecret(OAuthSecret secret) {
         if (secret == null || secret.getBaseUrl() == null || secret.getAppKey() == null) {
             log.error("OAuth 관련 환경 변수 누락");
-            throw new AuthException(_INTERNAL_SERVER_ERROR);
+            throw new AuthException(OAUTH_SECRET_NOT_FOUND);
         }
         return secret;
     }

--- a/src/main/java/com/dev/moim/global/security/feign/decoder/FeignErrorDecoder.java
+++ b/src/main/java/com/dev/moim/global/security/feign/decoder/FeignErrorDecoder.java
@@ -1,13 +1,11 @@
 package com.dev.moim.global.security.feign.decoder;
 
-import com.dev.moim.global.error.handler.AuthException;
-import feign.FeignException;
+import com.dev.moim.global.error.handler.FeignException;
 import feign.Response;
 import feign.codec.ErrorDecoder;
 import lombok.extern.slf4j.Slf4j;
 
-import static com.dev.moim.global.common.code.status.ErrorStatus.OAUTH_INVALID_TOKEN;
-import static com.dev.moim.global.common.code.status.ErrorStatus.USER_PROPERTY_NOT_FOUND;
+import static com.dev.moim.global.common.code.status.ErrorStatus.*;
 
 @Slf4j
 public class FeignErrorDecoder implements ErrorDecoder {
@@ -15,11 +13,18 @@ public class FeignErrorDecoder implements ErrorDecoder {
     @Override
     public Exception decode(String methodKey, Response response) {
 
+        log.error("response.status : {}", response.status());
+        log.error("response.body : {}", response.body());
+        log.error("response : {}", response);
+
         if (response.status() == 400) {
-            return new AuthException(USER_PROPERTY_NOT_FOUND);
+            log.error("ERROR STATUS 400");
+            return new FeignException(USER_PROPERTY_NOT_FOUND);
         } else if (response.status() == 401) {
-            return new AuthException(OAUTH_INVALID_TOKEN);
+            log.error("ERROR STATUS 401");
+            return new FeignException(OAUTH_INVALID_TOKEN);
+        } else {
+            return new FeignException(FEIGN_UNKNOWN_ERROR);
         }
-        return FeignException.errorStatus(methodKey, response);
     }
 }

--- a/src/main/java/com/dev/moim/global/security/filter/CustomLoginFilter.java
+++ b/src/main/java/com/dev/moim/global/security/filter/CustomLoginFilter.java
@@ -2,6 +2,7 @@ package com.dev.moim.global.security.filter;
 
 import com.dev.moim.domain.account.dto.LoginRequest;
 import com.dev.moim.domain.account.dto.TokenResponse;
+import com.dev.moim.global.error.handler.AuthException;
 import com.dev.moim.global.redis.util.RedisUtil;
 import com.dev.moim.global.common.BaseResponse;
 import com.dev.moim.global.common.code.status.ErrorStatus;
@@ -34,7 +35,6 @@ import static com.dev.moim.global.common.code.status.SuccessStatus._OK;
 @RequiredArgsConstructor
 public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
 
-
     private final AuthenticationManager authenticationManager;
     private final JwtUtil jwtUtil;
     private final RedisUtil redisUtil;
@@ -42,8 +42,7 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
     @Override
     public Authentication attemptAuthentication(
             @NonNull HttpServletRequest request,
-            @NonNull HttpServletResponse response) throws AuthenticationException {
-        log.info("** LoginFilter **");
+            @NonNull HttpServletResponse response) throws AuthenticationException, AuthException {
 
         LoginRequest logInRequest = HttpRequestUtil.readBody(request, LoginRequest.class);
 
@@ -59,7 +58,6 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
             @NonNull HttpServletResponse response,
             @NonNull FilterChain chain,
             @NonNull Authentication authResult) throws IOException{
-
         SecurityContextHolder.getContext().setAuthentication(authResult);
 
         PrincipalDetails principalDetails = (PrincipalDetails) authResult.getPrincipal();
@@ -86,6 +84,8 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
         } else {
             errorStatus = AUTHENTICATION_FAILED;
         }
+        log.error("[ERROR] : {}", errorStatus);
+
         BaseResponse<Object> errorResponse = BaseResponse.onFailure(
                 errorStatus.getCode(),
                 errorStatus.getMessage(),

--- a/src/main/java/com/dev/moim/global/security/filter/CustomLoginFilter.java
+++ b/src/main/java/com/dev/moim/global/security/filter/CustomLoginFilter.java
@@ -2,7 +2,6 @@ package com.dev.moim.global.security.filter;
 
 import com.dev.moim.domain.account.dto.LoginRequest;
 import com.dev.moim.domain.account.dto.TokenResponse;
-import com.dev.moim.global.error.handler.AuthException;
 import com.dev.moim.global.redis.util.RedisUtil;
 import com.dev.moim.global.common.BaseResponse;
 import com.dev.moim.global.common.code.status.ErrorStatus;
@@ -42,7 +41,7 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
     @Override
     public Authentication attemptAuthentication(
             @NonNull HttpServletRequest request,
-            @NonNull HttpServletResponse response) throws AuthenticationException, AuthException {
+            @NonNull HttpServletResponse response) throws AuthenticationException {
 
         LoginRequest logInRequest = HttpRequestUtil.readBody(request, LoginRequest.class);
 
@@ -78,7 +77,7 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
         ErrorStatus errorStatus;
 
         if (failed instanceof UsernameNotFoundException) {
-            errorStatus = USER_NOT_FOUND;
+            errorStatus = USER_UNREGISTERED;
         } else if (failed instanceof BadCredentialsException) {
             errorStatus = BAD_CREDENTIALS;
         } else {

--- a/src/main/java/com/dev/moim/global/security/filter/CustomLogoutHandler.java
+++ b/src/main/java/com/dev/moim/global/security/filter/CustomLogoutHandler.java
@@ -25,8 +25,6 @@ public class CustomLogoutHandler implements LogoutHandler {
     @Override
     public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
 
-        log.info("** logoutFilter **");
-
         try {
             String accessToken = jwtUtil.resolveToken(request);
 

--- a/src/main/java/com/dev/moim/global/security/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/dev/moim/global/security/filter/JwtExceptionFilter.java
@@ -3,19 +3,25 @@ package com.dev.moim.global.security.filter;
 import com.dev.moim.global.common.BaseResponse;
 import com.dev.moim.global.common.code.status.ErrorStatus;
 import com.dev.moim.global.error.handler.AuthException;
+import com.dev.moim.global.error.handler.FeignException;
 import com.dev.moim.global.security.util.HttpResponseUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 @Slf4j
+@RequiredArgsConstructor
 public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    private final String[] excludePath;
 
     @Override
     protected void doFilterInternal(
@@ -24,17 +30,25 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
             @NonNull FilterChain filterChain)
             throws ServletException, IOException {
         try {
-            log.info("** JwtExceptionFilter **");
             filterChain.doFilter(request, response);
-        } catch (AuthException e) {
-            ErrorStatus code = (ErrorStatus) e.getCode();
+        } catch (AuthException | FeignException e) {
+            log.error("[ERROR] : {}", e.getCode());
+
+            ErrorStatus errorStatus = (ErrorStatus) e.getCode();
 
             BaseResponse<Object> errorResponse = BaseResponse.onFailure(
-                            code.getCode(),
-                            code.getMessage(),
-                            e.getMessage());
+                    errorStatus.getCode(),
+                    errorStatus.getMessage(),
+                    null);
 
             HttpResponseUtil.setErrorResponse(response, e.getErrorReasonHttpStatus().getHttpStatus(), errorResponse);
         }
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String path = request.getRequestURI();
+
+        return Arrays.stream(excludePath).anyMatch(path::startsWith);
     }
 }

--- a/src/main/java/com/dev/moim/global/security/filter/OAuthLoginFilter.java
+++ b/src/main/java/com/dev/moim/global/security/filter/OAuthLoginFilter.java
@@ -5,6 +5,7 @@ import com.dev.moim.domain.account.dto.TokenResponse;
 import com.dev.moim.domain.account.entity.User;
 import com.dev.moim.domain.account.entity.enums.Provider;
 import com.dev.moim.domain.account.repository.UserRepository;
+import com.dev.moim.global.error.handler.AuthException;
 import com.dev.moim.global.redis.util.RedisUtil;
 import com.dev.moim.global.security.principal.PrincipalDetails;
 import com.dev.moim.global.security.util.*;
@@ -46,16 +47,12 @@ public class OAuthLoginFilter extends AbstractAuthenticationProcessingFilter {
     @Override
     public Authentication attemptAuthentication(
             @NonNull HttpServletRequest request,
-            @NonNull HttpServletResponse response) throws IOException, ServletException {
-
-        log.info("** OAuthLoginFilter **");
+            @NonNull HttpServletResponse response) throws IOException, ServletException, AuthException {
 
         OAuthLoginRequest oAuthLoginRequest = HttpRequestUtil.readBody(request, OAuthLoginRequest.class);
 
         Provider provider = oAuthLoginRequest.provider();
         String token = oAuthLoginRequest.token();
-
-        log.info("token : {}", token);
 
         if (provider == NAVER) {
             return authenticationManager.authenticate(new NaverLoginAuthenticationToken(provider, null, token));

--- a/src/main/java/com/dev/moim/global/security/principal/PrincipalDetails.java
+++ b/src/main/java/com/dev/moim/global/security/principal/PrincipalDetails.java
@@ -37,9 +37,7 @@ public record PrincipalDetails(User user) implements UserDetails {
     }
 
     @Override
-    public String getPassword() {
-        return user.getPassword();
-    }
+    public String getPassword() {return user.getPassword();}
 
     @Override
     public boolean isAccountNonExpired() {

--- a/src/main/java/com/dev/moim/global/security/principal/PrincipalDetailsService.java
+++ b/src/main/java/com/dev/moim/global/security/principal/PrincipalDetailsService.java
@@ -2,8 +2,8 @@ package com.dev.moim.global.security.principal;
 
 import com.dev.moim.domain.account.entity.User;
 import com.dev.moim.domain.account.repository.UserRepository;
-import com.dev.moim.global.error.handler.AuthException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import static com.dev.moim.domain.account.entity.enums.Provider.LOCAL;
 import static com.dev.moim.global.common.code.status.ErrorStatus.USER_NOT_FOUND;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PrincipalDetailsService implements UserDetailsService {
@@ -21,7 +22,8 @@ public class PrincipalDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         User user = userRepository.findByEmailAndProvider(email, LOCAL)
-                .orElseThrow(() -> new AuthException(USER_NOT_FOUND));
+                .orElseThrow(() -> new UsernameNotFoundException(USER_NOT_FOUND.getMessage()));
+
         return new PrincipalDetails(user);
     }
 }

--- a/src/main/java/com/dev/moim/global/security/service/NaverLoginService.java
+++ b/src/main/java/com/dev/moim/global/security/service/NaverLoginService.java
@@ -1,7 +1,5 @@
 package com.dev.moim.global.security.service;
 
-import com.dev.moim.global.common.code.status.ErrorStatus;
-import com.dev.moim.global.error.handler.AuthException;
 import com.dev.moim.global.security.feign.request.NaverFeign;
 import com.dev.moim.global.security.dto.NaverUserInfo;
 import lombok.RequiredArgsConstructor;
@@ -17,12 +15,6 @@ public class NaverLoginService {
 
     public NaverUserInfo getUserInfo(String oAuthToken) {
 
-        try {
-            NaverUserInfo naverUserInfo = naverFeign.getUserInfo("bearer " + oAuthToken);
-
-            return naverUserInfo;
-        } catch (Exception e) {
-            throw new AuthException(ErrorStatus.OAUTH_INVALID_TOKEN);
-        }
+        return naverFeign.getUserInfo("bearer " + oAuthToken);
     }
 }

--- a/src/main/java/com/dev/moim/global/security/service/OIDCService.java
+++ b/src/main/java/com/dev/moim/global/security/service/OIDCService.java
@@ -37,7 +37,7 @@ public class OIDCService {
             oidcPublicKeyList = googleFeign.getGoogleOIDCOpenKeys();
         } else if (provider.equals(APPLE)) {
             oidcPublicKeyList = appleFeign.getAppleOIDCOpenKeys();
-        }else {
+        } else {
             throw new AuthException(PROVIDER_NOT_FOUND);
         }
 

--- a/src/main/java/com/dev/moim/global/security/util/HttpRequestUtil.java
+++ b/src/main/java/com/dev/moim/global/security/util/HttpRequestUtil.java
@@ -5,11 +5,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 
-import static com.dev.moim.global.common.code.status.ErrorStatus._BAD_REQUEST;
+import static com.dev.moim.global.common.code.status.ErrorStatus.*;
 
+@Slf4j
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class HttpRequestUtil {
     private static final ObjectMapper objectMapper = new ObjectMapper();
@@ -18,14 +20,14 @@ public class HttpRequestUtil {
         try {
             return objectMapper.readValue(request.getInputStream(), requestDTO);
         } catch (IOException e) {
-            throw new AuthException(_BAD_REQUEST);
+            throw new AuthException(INVALID_REQUEST_BODY);
         }
     }
 
     public static String readHeader(HttpServletRequest request, String headerName) {
         String headerValue = request.getHeader(headerName);
         if (headerValue == null || headerValue.isEmpty()) {
-            throw new AuthException(_BAD_REQUEST);
+            throw new AuthException(INVALID_REQUEST_HEADER);
         }
         return headerValue;
     }

--- a/src/main/java/com/dev/moim/global/security/util/NaverLoginAuthenticationProvider.java
+++ b/src/main/java/com/dev/moim/global/security/util/NaverLoginAuthenticationProvider.java
@@ -1,5 +1,6 @@
 package com.dev.moim.global.security.util;
 
+import com.dev.moim.global.error.handler.FeignException;
 import com.dev.moim.global.security.dto.NaverUserInfo;
 import com.dev.moim.global.security.service.NaverLoginService;
 import lombok.RequiredArgsConstructor;
@@ -19,9 +20,7 @@ public class NaverLoginAuthenticationProvider implements AuthenticationProvider 
     private final NaverLoginService naverLoginService;
 
     @Override
-    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
-
-        log.info("** NaverLoginAuthenticationProvider **");
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException, FeignException {
 
         NaverLoginAuthenticationToken naverAuthenticationToken = (NaverLoginAuthenticationToken) authentication;
 

--- a/src/main/java/com/dev/moim/global/security/util/OIDCAuthenticationProvider.java
+++ b/src/main/java/com/dev/moim/global/security/util/OIDCAuthenticationProvider.java
@@ -19,9 +19,6 @@ public class OIDCAuthenticationProvider implements AuthenticationProvider {
 
     @Override
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
-
-        log.info("** OIDCAuthenticationProvider **");
-
         OIDCAuthenticationToken oidcAuthenticationToken = (OIDCAuthenticationToken) authentication;
 
         Provider provider = oidcAuthenticationToken.getPrincipal();

--- a/src/main/java/com/dev/moim/global/validation/validator/LocalAccountValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/LocalAccountValidator.java
@@ -24,18 +24,20 @@ public class LocalAccountValidator implements ConstraintValidator<LocalAccountVa
 
     @Override
     public boolean isValid(JoinRequest request, ConstraintValidatorContext context) {
+        if (request.provider() == LOCAL) {
+            return validateEmailDuplication(request.email(), context);
+        }
+        return true;
+    }
 
-        if (request.provider() != LOCAL) return true;
-
-        boolean isDuplicated = userRepository.existsByEmail(request.email());
-
-        if (isDuplicated) {
+    private boolean validateEmailDuplication(String email, ConstraintValidatorContext context) {
+        if (userRepository.existsByEmail(email)) {
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate(EMAIL_DUPLICATION.getMessage())
                     .addPropertyNode("email")
                     .addConstraintViolation();
 
-            log.warn("이미 가입된 메일입니다.");
+            log.warn("회원가입 실패 : 이메일 중복");
             return false;
         }
         return true;

--- a/src/main/java/com/dev/moim/global/validation/validator/PasswordValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/PasswordValidator.java
@@ -23,20 +23,22 @@ public class PasswordValidator implements ConstraintValidator<PasswordValidation
 
     @Override
     public boolean isValid(JoinRequest request, ConstraintValidatorContext context) {
+        if (request.provider() == LOCAL && !isPasswordValid(request.password(), context)) {
+            log.warn("회원가입 실패 : 비밀번호 조건 미충족");
+            return false;
+        }
+        return true;
+    }
 
-        log.info("PasswordValidator");
+    private boolean isPasswordValid(String password, ConstraintValidatorContext context) {
+        String passwordPattern = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[\\W_]).{8,16}$";
 
-        if (request.provider() == LOCAL) {
-            String passwordPattern = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[\\W_]).{8,16}$";
-            if (request.password() == null || !request.password().matches(passwordPattern)) {
-                context.disableDefaultConstraintViolation();
-                context.buildConstraintViolationWithTemplate(INVALID_PASSWORD.getMessage())
-                        .addPropertyNode("password")
-                        .addConstraintViolation();
-
-                log.warn("비밀번호 조건에 맞지 않습니다.");
-                return false;
-            }
+        if (password == null || !password.matches(passwordPattern)) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(INVALID_PASSWORD.getMessage())
+                    .addPropertyNode("password")
+                    .addConstraintViolation();
+            return false;
         }
         return true;
     }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #67

## 📌 개요
- 유저 인증 관련 예외 처리

## 🔁 변경 사항
**✔️ 18dd491813a8180281e7a4a89117acaea60e1b83 : 회원가입 DTO 검증 어노테이션 조건 추가**
- 소셜 로그인 회원가입 DTO에서 providerId를 필수로 받도록 조건을 추가했습니다

**✔️ 1e266a474ee1ad46a3414973fbd699ffd653b3fa : 유저 인증 예외 처리**
- 예외 처리를 명확하게 하기 위해 유저 인증 관련 예외 로직을 리팩토링 했습니다. feign client 관련 예외 FeignException을 따로 만들었고, JwtExceptionFilter와 JwtFilter에 shouldNotFilter 메서드를 추가했습니다. auth 관련 로직에서 발생하는 예외들을 AuthException으로 던져서 jwtException에서 처리되도록 구현했습니다.

**✔️ 6ae3e72fc51c525138ff0f77ec29f46a0c333968 : 일반로그인 UsernameNotFound 예외 뜨도록 설정**
 - 일반 로그인의 경우 UsernamePasswordAuthenticationFilter를 커스텀하면서 DaoAuthenticationProvider에 의해 authenticate가 진행됐습니다. DaoAuthenticationProvider를 따로 커스텀하지 않았기 때문에 기본 로직에 따라 이메일이 존재하지 않을 때에도 BadCredentialsException 예외로 나왔습니다. 해당 메일로 등록된 계정 자체가 존재하지 않음을 알려주기 위해 UsernameNotFoundException 예외로 나오도록 구현하고자 SecurityConfig에서, HideUserNotFoundException 조건을 false로 설정하여 인증 실패 시 UsernameNotFoundException을 숨기지 않도록 DaoAuthenticationProvider를 설정하고 providerManager에 해당 provider를 추가했습니다.

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
- 유저 인증 실패 시 발생하는 AuthenticationException 예외를 처리하는 JwtAuthenticationEntryPoint도 따로 있는데, authenticate 하는 과정에서 발생하는 예외를 좀 더 명확하게 처리하고자 authException으로 던지도록 하고 jwtException에서 해당 에러 메세지를 응답으로 만들도록 구현했는데, AuthenticationEntryPoint의 역할에 대해 좀 더 고민해봐야할 것 같습니다.

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
