### PR TITLE
✨ Feature: 유저 개인 일정 조회 기능 구현

### DIFF
--- a/src/main/java/com/dev/moim/domain/moim/controller/MoimCalendarController.java
+++ b/src/main/java/com/dev/moim/domain/moim/controller/MoimCalendarController.java
@@ -18,6 +18,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Validated
 @RestController
 @RequiredArgsConstructor
@@ -28,17 +30,30 @@ public class MoimCalendarController {
     private final CalenderCommandService calenderCommandService;
     private final CalenderQueryService calenderQueryService;
 
-    @Operation(summary = "모임 개인 일정 조회", description = "유저의 개인 일정 및 참여하는 모임의 일정들을 조회합니다.")
+    @Operation(summary = "개인 일정 조회", description = "유저의 개인 일정들을 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "유저 일정 조회 성공"),
     })
     @GetMapping("/calender")
-    public BaseResponse<PlanMonthListDTO> getIndividualPlans(
+    public BaseResponse<PlanMonthListDTO<List<UserPlanDTO>>> getIndividualPlans(
             @AuthUser User user,
             @Parameter(description = "연도") @RequestParam int year,
             @Parameter(description = "월") @RequestParam int month
     ) {
         return BaseResponse.onSuccess(calenderQueryService.getIndividualPlans(user, year, month));
+    }
+
+    @Operation(summary = "유저가 참여 신청한 모임 일정 조회", description = "유저가 참여 신청한 모임 일정들을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "유저 일정 조회 성공"),
+    })
+    @GetMapping("/calender")
+    public BaseResponse<PlanMonthListDTO<List<UserPlanDTO>>> getUserPlans(
+            @AuthUser User user,
+            @Parameter(description = "연도") @RequestParam int year,
+            @Parameter(description = "월") @RequestParam int month
+    ) {
+        return BaseResponse.onSuccess(calenderQueryService.getUserPlans(user, year, month));
     }
 
     @Operation(summary = "모임 일정 조회", description = "달력에서 특정 연도, 월에 등록되어 있는 일정들을 조회합니다. 모임에 참여하는 멤버만 조회 가능 합니다.")
@@ -47,7 +62,7 @@ public class MoimCalendarController {
             @ApiResponse(responseCode = "MOIM_001", description = "모임을 찾을 수 없습니다.")
     })
     @GetMapping("/{moimId}/calender")
-    public BaseResponse<PlanMonthListDTO> getMoimPlans(
+    public BaseResponse<PlanMonthListDTO<PlanDayListDTO>> getMoimPlans(
             @AuthUser User user,
             @PathVariable Long moimId,
             @Parameter(description = "연도") @RequestParam int year,

--- a/src/main/java/com/dev/moim/domain/moim/controller/MoimCalendarController.java
+++ b/src/main/java/com/dev/moim/domain/moim/controller/MoimCalendarController.java
@@ -34,7 +34,7 @@ public class MoimCalendarController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "유저 일정 조회 성공"),
     })
-    @GetMapping("/calender")
+    @GetMapping("/calender/individual-plans")
     public BaseResponse<PlanMonthListDTO<List<UserPlanDTO>>> getIndividualPlans(
             @AuthUser User user,
             @Parameter(description = "연도") @RequestParam int year,
@@ -47,7 +47,7 @@ public class MoimCalendarController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "유저 일정 조회 성공"),
     })
-    @GetMapping("/calender")
+    @GetMapping("/calender/user-moim-plans")
     public BaseResponse<PlanMonthListDTO<List<UserPlanDTO>>> getUserPlans(
             @AuthUser User user,
             @Parameter(description = "연도") @RequestParam int year,

--- a/src/main/java/com/dev/moim/domain/moim/controller/MoimCalendarController.java
+++ b/src/main/java/com/dev/moim/domain/moim/controller/MoimCalendarController.java
@@ -28,19 +28,32 @@ public class MoimCalendarController {
     private final CalenderCommandService calenderCommandService;
     private final CalenderQueryService calenderQueryService;
 
+    @Operation(summary = "모임 개인 일정 조회", description = "유저의 개인 일정 및 참여하는 모임의 일정들을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "유저 일정 조회 성공"),
+    })
+    @GetMapping("/calender")
+    public BaseResponse<PlanMonthListDTO> getIndividualPlans(
+            @AuthUser User user,
+            @Parameter(description = "연도") @RequestParam int year,
+            @Parameter(description = "월") @RequestParam int month
+    ) {
+        return BaseResponse.onSuccess(calenderQueryService.getIndividualPlans(user, year, month));
+    }
+
     @Operation(summary = "모임 일정 조회", description = "달력에서 특정 연도, 월에 등록되어 있는 일정들을 조회합니다. 모임에 참여하는 멤버만 조회 가능 합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "모임 일정 조회 성공"),
             @ApiResponse(responseCode = "MOIM_001", description = "모임을 찾을 수 없습니다.")
     })
     @GetMapping("/{moimId}/calender")
-    public BaseResponse<PlanMonthListDTO> getPlans(
+    public BaseResponse<PlanMonthListDTO> getMoimPlans(
             @AuthUser User user,
             @PathVariable Long moimId,
             @Parameter(description = "연도") @RequestParam int year,
             @Parameter(description = "월") @RequestParam int month
     ) {
-        return BaseResponse.onSuccess(calenderQueryService.getPlans(user, moimId, year, month));
+        return BaseResponse.onSuccess(calenderQueryService.getMoimPlans(user, moimId, year, month));
     }
 
     @Operation(summary = "모임 새로운 일정 추가", description = "상세 스케줄, 알림 설정은 필수 입력 정보는 아닙니다.")

--- a/src/main/java/com/dev/moim/domain/moim/dto/calender/MoimPlanDTO.java
+++ b/src/main/java/com/dev/moim/domain/moim/dto/calender/MoimPlanDTO.java
@@ -4,7 +4,7 @@ import com.dev.moim.domain.moim.entity.Plan;
 
 import java.time.LocalDateTime;
 
-public record PlanDTO(
+public record MoimPlanDTO(
         Long planId,
         String title,
         String location,
@@ -12,8 +12,8 @@ public record PlanDTO(
         LocalDateTime time,
         boolean isParticipant
 ) {
-    public static PlanDTO from(Plan plan, boolean isParticipant) {
-        return new PlanDTO(
+    public static MoimPlanDTO from(Plan plan, boolean isParticipant) {
+        return new MoimPlanDTO(
                 plan.getId(),
                 plan.getTitle(),
                 plan.getLocation(),

--- a/src/main/java/com/dev/moim/domain/moim/dto/calender/PlanDayListDTO.java
+++ b/src/main/java/com/dev/moim/domain/moim/dto/calender/PlanDayListDTO.java
@@ -4,6 +4,6 @@ import java.util.List;
 
 public record PlanDayListDTO(
         int memberWithPlanCnt,
-        List<PlanDTO> planList
+        List<MoimPlanDTO> planList
 ) {
 }

--- a/src/main/java/com/dev/moim/domain/moim/dto/calender/PlanMonthListDTO.java
+++ b/src/main/java/com/dev/moim/domain/moim/dto/calender/PlanMonthListDTO.java
@@ -2,7 +2,7 @@ package com.dev.moim.domain.moim.dto.calender;
 
 import java.util.Map;
 
-public record PlanMonthListDTO(
-        Map<Integer, PlanDayListDTO> planList
+public record PlanMonthListDTO<T>(
+        Map<Integer, T> planList
 ) {
 }

--- a/src/main/java/com/dev/moim/domain/moim/dto/calender/UserPlanDTO.java
+++ b/src/main/java/com/dev/moim/domain/moim/dto/calender/UserPlanDTO.java
@@ -1,0 +1,34 @@
+package com.dev.moim.domain.moim.dto.calender;
+
+import com.dev.moim.domain.moim.entity.IndividualPlan;
+import com.dev.moim.domain.moim.entity.Plan;
+
+import java.time.LocalDateTime;
+
+public record UserPlanDTO(
+        Long planId,
+        String title,
+        String location,
+        String locationDetail,
+        LocalDateTime time
+) {
+    public static UserPlanDTO of(IndividualPlan individualPlan) {
+        return new UserPlanDTO(
+                individualPlan.getId(),
+                individualPlan.getTitle(),
+                null,
+                null,
+                individualPlan.getDate()
+        );
+    }
+
+    public static UserPlanDTO of(Plan plan) {
+        return new UserPlanDTO(
+                plan.getId(),
+                plan.getTitle(),
+                plan.getLocation(),
+                plan.getLocationDetail(),
+                plan.getDate()
+        );
+    }
+}

--- a/src/main/java/com/dev/moim/domain/moim/entity/IndividualPlan.java
+++ b/src/main/java/com/dev/moim/domain/moim/entity/IndividualPlan.java
@@ -22,7 +22,7 @@ public class IndividualPlan extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String content;
+    private String title;
 
     private LocalDateTime date;
 

--- a/src/main/java/com/dev/moim/domain/moim/entity/IndividualPlan.java
+++ b/src/main/java/com/dev/moim/domain/moim/entity/IndividualPlan.java
@@ -1,0 +1,32 @@
+package com.dev.moim.domain.moim.entity;
+
+import com.dev.moim.domain.account.entity.User;
+import com.dev.moim.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@DynamicInsert
+@DynamicUpdate
+public class IndividualPlan extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String content;
+
+    private LocalDateTime date;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/src/main/java/com/dev/moim/domain/moim/repository/IndividualPlanRepository.java
+++ b/src/main/java/com/dev/moim/domain/moim/repository/IndividualPlanRepository.java
@@ -1,0 +1,7 @@
+package com.dev.moim.domain.moim.repository;
+
+import com.dev.moim.domain.moim.entity.IndividualPlan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IndividualPlanRepository extends JpaRepository<IndividualPlan, Long> {
+}

--- a/src/main/java/com/dev/moim/domain/moim/repository/IndividualPlanRepository.java
+++ b/src/main/java/com/dev/moim/domain/moim/repository/IndividualPlanRepository.java
@@ -3,5 +3,10 @@ package com.dev.moim.domain.moim.repository;
 import com.dev.moim.domain.moim.entity.IndividualPlan;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public interface IndividualPlanRepository extends JpaRepository<IndividualPlan, Long> {
+
+    List<IndividualPlan> findByDateBetween(LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/com/dev/moim/domain/moim/repository/UserPlanRepository.java
+++ b/src/main/java/com/dev/moim/domain/moim/repository/UserPlanRepository.java
@@ -13,10 +13,15 @@ public interface UserPlanRepository extends JpaRepository<UserPlan, Long> {
 
     Boolean existsByPlanIdAndUserId(Long planId, Long userId);
 
-    @Query("SELECT COUNT(DISTINCT up.user.id) FROM UserPlan up " +
-            "JOIN up.plan p " +
-            "WHERE p.date >= :startDate AND p.date <= :endDate " +
-            "AND up.user.id IN (SELECT um.user.id FROM UserMoim um WHERE um.moim.id = :moimId)")
+    @Query("SELECT COUNT(DISTINCT u.id) " +
+            "FROM User u " +
+            "LEFT JOIN UserPlan up ON u.id = up.user.id " +
+            "LEFT JOIN Plan p ON up.plan.id = p.id " +
+            "LEFT JOIN IndividualPlan ip ON u.id = ip.user.id " +
+            "WHERE (p.date BETWEEN :startDate AND :endDate AND up.user.id IN " +
+            "(SELECT um.user.id FROM UserMoim um WHERE um.moim.id = :moimId)) " +
+            "OR (ip.date BETWEEN :startDate AND :endDate AND u.id IN " +
+            "(SELECT um.user.id FROM UserMoim um WHERE um.moim.id = :moimId))")
     int countUsersWithPlansInDateRange(@Param("moimId") Long moimId,
                                        @Param("startDate") LocalDateTime startDate,
                                        @Param("endDate") LocalDateTime endDate);

--- a/src/main/java/com/dev/moim/domain/moim/repository/UserPlanRepository.java
+++ b/src/main/java/com/dev/moim/domain/moim/repository/UserPlanRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface UserPlanRepository extends JpaRepository<UserPlan, Long> {
 
@@ -31,4 +32,6 @@ public interface UserPlanRepository extends JpaRepository<UserPlan, Long> {
     Boolean existsByUserIdAndPlanId(Long userId, Long planId);
 
     Slice<UserPlan> findByPlanId(Long planId, PageRequest pageRequest);
+
+    List<UserPlan> findByUserIdAndPlanDateBetween(Long userId, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/com/dev/moim/domain/moim/service/CalenderQueryService.java
+++ b/src/main/java/com/dev/moim/domain/moim/service/CalenderQueryService.java
@@ -1,16 +1,17 @@
 package com.dev.moim.domain.moim.service;
 
 import com.dev.moim.domain.account.entity.User;
-import com.dev.moim.domain.moim.dto.calender.PlanDetailDTO;
-import com.dev.moim.domain.moim.dto.calender.PlanMonthListDTO;
-import com.dev.moim.domain.moim.dto.calender.PlanParticipantListPageDTO;
-import com.dev.moim.domain.moim.dto.calender.ScheduleListDTO;
+import com.dev.moim.domain.moim.dto.calender.*;
+
+import java.util.List;
 
 public interface CalenderQueryService {
 
-    PlanMonthListDTO getIndividualPlans(User user, int year, int month);
+    PlanMonthListDTO<List<UserPlanDTO>> getIndividualPlans(User user, int year, int month);
 
-    PlanMonthListDTO getMoimPlans(User user, Long moimId, int year, int month);
+    PlanMonthListDTO<List<UserPlanDTO>> getUserPlans(User user, int year, int month);
+
+    PlanMonthListDTO<PlanDayListDTO> getMoimPlans(User user, Long moimId, int year, int month);
 
     PlanDetailDTO getPlanDetails(User user, Long planId);
 

--- a/src/main/java/com/dev/moim/domain/moim/service/CalenderQueryService.java
+++ b/src/main/java/com/dev/moim/domain/moim/service/CalenderQueryService.java
@@ -8,7 +8,9 @@ import com.dev.moim.domain.moim.dto.calender.ScheduleListDTO;
 
 public interface CalenderQueryService {
 
-    PlanMonthListDTO getPlans(User user, Long moimId, int year, int month);
+    PlanMonthListDTO getIndividualPlans(User user, int year, int month);
+
+    PlanMonthListDTO getMoimPlans(User user, Long moimId, int year, int month);
 
     PlanDetailDTO getPlanDetails(User user, Long planId);
 

--- a/src/main/java/com/dev/moim/domain/moim/service/impl/CalenderQueryServiceImpl.java
+++ b/src/main/java/com/dev/moim/domain/moim/service/impl/CalenderQueryServiceImpl.java
@@ -41,7 +41,7 @@ public class CalenderQueryServiceImpl implements CalenderQueryService {
     private final IndividualPlanRepository individualPlanRepository;
 
     @Override
-    public PlanMonthListDTO getIndividualPlans(User user, int year, int month) {
+    public PlanMonthListDTO<List<UserPlanDTO>> getIndividualPlans(User user, int year, int month) {
 
         YearMonth yearMonth = YearMonth.of(year, month);
         LocalDateTime startDate = yearMonth.atDay(1).atStartOfDay();
@@ -53,11 +53,26 @@ public class CalenderQueryServiceImpl implements CalenderQueryService {
                 .map(UserPlanDTO::of)
                 .collect(Collectors.groupingBy(dto -> dto.time().getDayOfMonth()));
 
-        return new PlanMonthListDTO(monthPlanListByDay);
+        return new PlanMonthListDTO<>(monthPlanListByDay);
     }
 
     @Override
-    public PlanMonthListDTO getMoimPlans(User user, Long moimId, int year, int month) {
+    public PlanMonthListDTO<List<UserPlanDTO>> getUserPlans(User user, int year, int month) {
+        YearMonth yearMonth = YearMonth.of(year, month);
+        LocalDateTime startDate = yearMonth.atDay(1).atStartOfDay();
+        LocalDateTime endDate = yearMonth.atEndOfMonth().atTime(23, 59, 59);
+
+        List<UserPlan> userPlanList = userPlanRepository.findByUserIdAndPlanDateBetween(user.getId(), startDate, endDate);
+
+        Map<Integer, List<UserPlanDTO>> planListByDay = userPlanList.stream()
+                .map(userPlan -> UserPlanDTO.of(userPlan.getPlan()))
+                .collect(Collectors.groupingBy(dto -> dto.time().getDayOfMonth()));
+
+        return new PlanMonthListDTO<>(planListByDay);
+    }
+
+    @Override
+    public PlanMonthListDTO<PlanDayListDTO> getMoimPlans(User user, Long moimId, int year, int month) {
 
         YearMonth yearMonth = YearMonth.of(year, month);
         LocalDateTime startDate = yearMonth.atDay(1).atStartOfDay();
@@ -87,7 +102,7 @@ public class CalenderQueryServiceImpl implements CalenderQueryService {
             planDayListMap.put(day, new PlanDayListDTO(memberWithPlanCnt, planList));
         }
 
-        return new PlanMonthListDTO(planDayListMap);
+        return new PlanMonthListDTO<>(planDayListMap);
     }
 
     @Override

--- a/src/main/java/com/dev/moim/domain/user/UserService.java
+++ b/src/main/java/com/dev/moim/domain/user/UserService.java
@@ -1,7 +1,5 @@
 package com.dev.moim.domain.user;
 
-import com.dev.moim.domain.account.entity.User;
-import com.dev.moim.domain.user.dto.ProfileDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/dev/moim/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/dev/moim/global/security/config/SecurityConfig.java
@@ -22,6 +22,7 @@ import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -32,7 +33,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.security.web.authentication.logout.LogoutFilter;
 
 @Configuration
-//@EnableWebSecurity(debug = true)
+// @EnableWebSecurity(debug = true)
 @RequiredArgsConstructor
 public class SecurityConfig {
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #78

## 📌 개요
- 유저 개인 일정 조회 기능 구현

## 🔁 변경 사항
✔️ 644aeb9ee2bedef4c5177025de3bacdbf1e041ef : 개인 일정 엔티티 추가
✔️ 0c4415b977b5424896aad823a3d301861cb58a17 : 개인 일정 repository 추가
✔️ 36e25aa15cfbb3a96ad38d839616d0e55fe16772 : 유저 개인 일정 조회
✔️ ff97f7063af8a0a9ef655de729faa7349ec9f56d : 일정 있는 모임 멤버 수 count 로직 수정
✔️ a175175ee685eb09fd83f83aa506ff2240ad6e49 : 유저가 참여 신청한 모임 일정 조회
✔️ d78ddb70d4b83c03bbf8c272b786569c1f2f28b5 : 유저 일정 조회 엔드포인트 수정

유저의 개인 일정을 조회하는 기능을 구현했습니다.


## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
- 유저의 일정으로 "유저의 개인 일정", "유저가 참여신청한 모임 일정" 2가지가 있는데 현재는 API를 분리해둔 상태인데 하나의 API로 두는게 좋을지 좀 더 고려해보겠습니다.


## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
