### PR TITLE
♻️ [Refactor] jwt 관련 로직 수정

### DIFF
--- a/src/main/java/com/dev/moim/domain/account/dto/LoginResponseDTO.java
+++ b/src/main/java/com/dev/moim/domain/account/dto/LoginResponseDTO.java
@@ -1,0 +1,11 @@
+package com.dev.moim.domain.account.dto;
+
+import com.dev.moim.domain.account.entity.enums.Provider;
+
+public record LoginResponseDTO(
+        String accessToken,
+        String refreshToken,
+        Provider provider,
+        String email
+) {
+}

--- a/src/main/java/com/dev/moim/global/redis/config/RedisCacheConfig.java
+++ b/src/main/java/com/dev/moim/global/redis/config/RedisCacheConfig.java
@@ -27,7 +27,7 @@ public class RedisCacheConfig {
                         .serializeValuesWith(
                                 RedisSerializationContext.SerializationPair.fromSerializer(
                                         new GenericJackson2JsonRedisSerializer()))
-                        .entryTtl(Duration.ofDays(7L));
+                        .entryTtl(Duration.ofDays(3L));
 
         return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf)
                 .cacheDefaults(redisCacheConfiguration)

--- a/src/main/java/com/dev/moim/global/security/feign/request/AppleFeign.java
+++ b/src/main/java/com/dev/moim/global/security/feign/request/AppleFeign.java
@@ -2,6 +2,7 @@ package com.dev.moim.global.security.feign.request;
 
 import com.dev.moim.global.security.feign.config.AppleFeignConfiguration;
 import com.dev.moim.global.security.feign.dto.OIDCPublicKeyListDTO;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.GetMapping;
         configuration = AppleFeignConfiguration.class
 )
 public interface AppleFeign {
+    @Cacheable(cacheNames = "APPLE", cacheManager = "oidcCacheManager")
     @GetMapping("/auth/keys")
     OIDCPublicKeyListDTO getAppleOIDCOpenKeys();
 }

--- a/src/main/java/com/dev/moim/global/security/feign/request/GoogleFeign.java
+++ b/src/main/java/com/dev/moim/global/security/feign/request/GoogleFeign.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.GetMapping;
         configuration = GoogleFeignConfiguration.class
 )
 public interface GoogleFeign {
-    @Cacheable(cacheNames = "GoogleOIDC", cacheManager = "oidcCacheManager")
+    @Cacheable(cacheNames = "GOOGLE", cacheManager = "oidcCacheManager")
     @GetMapping("/oauth2/v3/certs")
     OIDCPublicKeyListDTO getGoogleOIDCOpenKeys();
 }

--- a/src/main/java/com/dev/moim/global/security/feign/request/KakaoFeign.java
+++ b/src/main/java/com/dev/moim/global/security/feign/request/KakaoFeign.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.GetMapping;
         configuration = KakaoFeignConfiguration.class
 )
 public interface KakaoFeign {
-    @Cacheable(cacheNames = "KakaoOIDC", cacheManager = "oidcCacheManager")
+    @Cacheable(cacheNames = "KAKAO", cacheManager = "oidcCacheManager")
     @GetMapping("/.well-known/jwks.json")
     OIDCPublicKeyListDTO getKakaoOIDCOpenKeys();
 }

--- a/src/main/java/com/dev/moim/global/security/filter/CustomLogoutHandler.java
+++ b/src/main/java/com/dev/moim/global/security/filter/CustomLogoutHandler.java
@@ -32,7 +32,7 @@ public class CustomLogoutHandler implements LogoutHandler {
             Long expiration = jwtUtil.getExpiration(accessToken) - now;
             redisUtil.setValue(accessToken, "logout", expiration);
 
-            redisUtil.deleteValue(jwtUtil.getEmail(accessToken));
+            redisUtil.deleteValue(jwtUtil.getUserId(accessToken));
         } catch (ExpiredJwtException e) {
             throw new AuthException(AUTH_EXPIRED_TOKEN);
         }

--- a/src/main/java/com/dev/moim/global/security/filter/OAuthLoginFilter.java
+++ b/src/main/java/com/dev/moim/global/security/filter/OAuthLoginFilter.java
@@ -1,7 +1,7 @@
 package com.dev.moim.global.security.filter;
 
+import com.dev.moim.domain.account.dto.LoginResponseDTO;
 import com.dev.moim.domain.account.dto.OAuthLoginRequest;
-import com.dev.moim.domain.account.dto.TokenResponse;
 import com.dev.moim.domain.account.entity.User;
 import com.dev.moim.domain.account.entity.enums.Provider;
 import com.dev.moim.domain.account.repository.UserRepository;
@@ -55,9 +55,9 @@ public class OAuthLoginFilter extends AbstractAuthenticationProcessingFilter {
         String token = oAuthLoginRequest.token();
 
         if (provider == NAVER) {
-            return authenticationManager.authenticate(new NaverLoginAuthenticationToken(provider, null, token));
+            return authenticationManager.authenticate(new NaverLoginAuthenticationToken(provider, null, token, null));
         } else {
-            return authenticationManager.authenticate(new OIDCAuthenticationToken(provider, null, token));
+            return authenticationManager.authenticate(new OIDCAuthenticationToken(provider, null, token, null));
         }
     }
 
@@ -79,10 +79,10 @@ public class OAuthLoginFilter extends AbstractAuthenticationProcessingFilter {
 
             redisUtil.setValue(principalDetails.user().getId().toString(), refreshToken, jwtUtil.getRefreshTokenValiditySec());
 
-            HttpResponseUtil.setSuccessResponse(response, _OK, new TokenResponse(accessToken, refreshToken, principalDetails.getProvider()));
+            HttpResponseUtil.setSuccessResponse(response, _OK, new LoginResponseDTO(accessToken, refreshToken, principalDetails.getProvider(), authResult.getName()));
         } else {
             log.info("신규 유저 : 추가 정보 입력 필요");
-            HttpResponseUtil.setSuccessResponse(response, UNREGISTERED_OAUTH_LOGIN_USER, new TokenResponse(null, null, UNREGISTERED));
+            HttpResponseUtil.setSuccessResponse(response, UNREGISTERED_OAUTH_LOGIN_USER, new LoginResponseDTO(null, null, UNREGISTERED, authResult.getName()));
         }
     }
 }

--- a/src/main/java/com/dev/moim/global/security/util/JwtOIDCUtil.java
+++ b/src/main/java/com/dev/moim/global/security/util/JwtOIDCUtil.java
@@ -75,6 +75,17 @@ public class JwtOIDCUtil {
                     .setSigningKey(getRSAPublicKey(modulus, exponent))
                     .build()
                     .parseClaimsJws(token);
+        } catch (ExpiredJwtException e) {
+            log.error("유저 인증 실패 : 토큰 만료 : {}", e.getMessage());
+            throw new AuthException(ID_TOKEN_EXPIRED);
+        } catch (UnsupportedJwtException |
+                 MalformedJwtException |
+                 ClaimJwtException e) {
+            log.error("유저 인증 실패 : {}", e.getMessage());
+            throw new AuthException(ID_TOKEN_INVALID);
+        } catch (JwtException e) {
+            log.error("유저 인증 실패 : JWT processing error: {}", e.getMessage());
+            throw new AuthException(ID_TOKEN_INVALID);
         } catch (Exception e) {
             log.error("JWT 파싱 실패 : {}", e.getMessage());
             throw new AuthException(ID_TOKEN_INVALID);

--- a/src/main/java/com/dev/moim/global/security/util/JwtUtil.java
+++ b/src/main/java/com/dev/moim/global/security/util/JwtUtil.java
@@ -60,18 +60,11 @@ public class JwtUtil {
 
         return Jwts.builder()
                 .setSubject(String.valueOf(principalDetails.getUserId()))
-                .claim("email", principalDetails.getUsername())
-                .claim("provider", principalDetails.getProvider())
-                .claim("providerId", principalDetails.getProviderId())
                 .claim("role", principalDetails.getAuthorities())
                 .setIssuedAt(Date.from(issuedAt))
                 .setExpiration(Date.from(expirationTime))
                 .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
-    }
-
-    public String getEmail(String token) {
-        return getClaims(token).getBody().get("email", String.class);
     }
 
     public String getUserId(String token) {

--- a/src/main/java/com/dev/moim/global/security/util/NaverLoginAuthenticationProvider.java
+++ b/src/main/java/com/dev/moim/global/security/util/NaverLoginAuthenticationProvider.java
@@ -26,7 +26,7 @@ public class NaverLoginAuthenticationProvider implements AuthenticationProvider 
 
         NaverUserInfo naverUserInfo = naverLoginService.getUserInfo(naverAuthenticationToken.getOAuthAccessToken());
 
-        return new NaverLoginAuthenticationToken(NAVER, naverUserInfo.getResponse().getId(), naverAuthenticationToken.getOAuthAccessToken());
+        return new NaverLoginAuthenticationToken(NAVER, naverUserInfo.getResponse().getId(), naverAuthenticationToken.getOAuthAccessToken(), naverAuthenticationToken.getName());
     }
 
     @Override

--- a/src/main/java/com/dev/moim/global/security/util/NaverLoginAuthenticationToken.java
+++ b/src/main/java/com/dev/moim/global/security/util/NaverLoginAuthenticationToken.java
@@ -6,16 +6,24 @@ import org.springframework.security.authentication.AbstractAuthenticationToken;
 
 @Getter
 public class NaverLoginAuthenticationToken extends AbstractAuthenticationToken {
+
     private final Provider provider;
     private final String providerId;
     private final String oAuthAccessToken;
+    private final String email;
 
-    public NaverLoginAuthenticationToken(Provider provider, String providerId, String oAuthAccessToken) {
+    public NaverLoginAuthenticationToken(Provider provider, String providerId, String oAuthAccessToken, String email) {
         super(null);
         this.provider = provider;
         this.providerId = providerId;
         this.oAuthAccessToken = oAuthAccessToken;
+        this.email = email;
         setAuthenticated(false);
+    }
+
+    @Override
+    public String getName() {
+        return email;
     }
 
     @Override

--- a/src/main/java/com/dev/moim/global/security/util/OIDCAuthenticationProvider.java
+++ b/src/main/java/com/dev/moim/global/security/util/OIDCAuthenticationProvider.java
@@ -26,7 +26,7 @@ public class OIDCAuthenticationProvider implements AuthenticationProvider {
 
         OIDCDecodePayload oidcDecodePayload = oidcService.getOIDCDecodePayload(provider, idToken);
 
-        return new OIDCAuthenticationToken(provider, oidcDecodePayload.sub(), idToken);
+        return new OIDCAuthenticationToken(provider, oidcDecodePayload.sub(), idToken, oidcDecodePayload.email());
     }
 
     @Override

--- a/src/main/java/com/dev/moim/global/security/util/OIDCAuthenticationToken.java
+++ b/src/main/java/com/dev/moim/global/security/util/OIDCAuthenticationToken.java
@@ -6,16 +6,24 @@ import org.springframework.security.authentication.AbstractAuthenticationToken;
 
 @Getter
 public class OIDCAuthenticationToken extends AbstractAuthenticationToken {
+
     private final Provider provider;
     private final String providerId;
     private final String idToken;
+    private final String email;
 
-    public OIDCAuthenticationToken(Provider provider, String providerId, String idToken) {
+    public OIDCAuthenticationToken(Provider provider, String providerId, String idToken, String email) {
         super(null);
         this.provider = provider;
         this.providerId = providerId;
         this.idToken = idToken;
+        this.email = email;
         setAuthenticated(false);
+    }
+
+    @Override
+    public String getName() {
+        return email;
     }
 
     @Override


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #90 

## 📌 개요
- jwt 관련 로직 수정

## 🔁 변경 사항
✔️ f26d0f6acc3ca2b568d239719f14ca34049998c9 : 소셜 로그인 성공 응답에 email 추가
- jwt를 생성할 때 sub 클레임에 유저id를 넣어서 토큰의 주체를 식별하고 있습니다. 또한 email, provider, providerId 클레임을 넣고있는데, 유저 정보에 해당하는 claim을 최소화하고자 sub만 남겼습니다.

✔️ 42b8ac50337391499255fa7a52bbbc9908e45164 : 삭제할 refreshToken 키 값 변경
- 기존에 중복된 email 가입이 불가능하도록해서 email로 유저를 구분할 수 있었기 때문에 refreshToken을 redis에 저장할 때 키 값을 email로 두었었는데, 이메일 변경이 가능한 애플 로그인을 도입하게 되면서 email로 유저를 구분할 수 없게 되었고 refreshToken 저장 시, 키 값으로  userId를 사용하게 되었습니다. 로그아웃 시 redis에 저장되어있던 refreshTokken을 삭제할 때에도 userId로 refreshToken을 찾도록 수정했습니다.

✔️ b57022b98d4f043c78f229ec8d7f026bd0f1023d : OIDC jwt 파싱 예외 처리 추가

✔️ 8211f0958b4c4d72d2b1ff1d571eabe510cb0327 : Redis 캐시 항목 TTL 설정 변경
✔️ fa9cf53e940fc9c1a088387cb2d7f157189edb84 : 공개키 목록 갱신 처리 로직 추가
- 구글 로그인 테스트를 진행했는데, redis에 캐시된 구글 공개키 리스트가 있었고 따라서 구글에 공개키 목록을 받아오는 요청이 나가지 않고 기존에 캐시된 공개키 리스트가 사용됐습니다. 그 기간 내에 구글 공개키 목록이 갱신되었고, 갱신되지 않은 공개키 리스트를 사용하면서, 헤더의 kid에 해당하는 공개키 값이 없어서 idToken의 유효성 검증에 실패하는 에러가 발생했습니다
캐시된 공개키 리스트에 헤더의 kid에 해당하는 공개키가 없는 경우에 대한 처리를 위해, 일치하는 공개키가 없는 경우 캐시된 공개키 리스트를 지우고 인증 서버로부터 공개키 리스트를 다시 받아오도록하는 로직을 추가했고, redis 캐시 항목 TTL을 3L로 변경했습니다.

✔️ f4100517bf791d0864777429d912a7c862543217 : 소셜 로그인 성공 응답에 email 추가
- 애플 로그인의 경우 유저 정보를 최초 1회만 획득할 수 있고 두번째 로그인 부터 email 값이 nil로 넘어옵니다. 소셜 로그인 filter를 거쳐서 idToken의 유효성 검증에 성공했지만 해당 유저가 회원가입되지 않은 유저여서 회원가입을 거쳐야하는 경우 email이 필요한데, 프론트 측에서 애플 서버로부터 해당 유저의 메일 정보를 받을 수 없습니다. 따라서 로그인 요청 응답으로 email을 넘겨주는 로직을 추가했습니다.


## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
