### PR TITLE
✨ Feature: 유저 특정 날짜 일정 개수 조회 기능 구현

### DIFF
--- a/src/main/java/com/dev/moim/domain/account/entity/User.java
+++ b/src/main/java/com/dev/moim/domain/account/entity/User.java
@@ -29,11 +29,13 @@ public class User extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private String email;
 
     private String password;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private Provider provider;
 
     private String providerId;
@@ -52,14 +54,17 @@ public class User extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @ColumnDefault("'FEMALE'")
+    @Column(nullable = false)
     private Gender gender;
 
+    @Column(nullable = false)
     private LocalDate birth;
 
     private double rating;
 
     @Enumerated(EnumType.STRING)
     @ColumnDefault("'ROLE_USER'")
+    @Column(nullable = false)
     private UserRole userRole;
 
     @Column(nullable = false)
@@ -69,6 +74,7 @@ public class User extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @ColumnDefault("'FREE'")
+    @Column(nullable = false)
     private UserRank userRank;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)

--- a/src/main/java/com/dev/moim/domain/account/entity/UserProfile.java
+++ b/src/main/java/com/dev/moim/domain/account/entity/UserProfile.java
@@ -31,12 +31,15 @@ public class UserProfile extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @ColumnDefault("'MAIN'")
+    @Column(nullable = false)
     private ProfileType profileType;
 
+    @Column(nullable = false)
     private String name;
 
     private String imageUrl;
 
+    @Column(nullable = false)
     private String residence;
 
     private String introduction;

--- a/src/main/java/com/dev/moim/domain/account/entity/UserReview.java
+++ b/src/main/java/com/dev/moim/domain/account/entity/UserReview.java
@@ -19,6 +19,7 @@ public class UserReview extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private Double rating;
 
     private String content;

--- a/src/main/java/com/dev/moim/domain/moim/controller/MoimCalendarController.java
+++ b/src/main/java/com/dev/moim/domain/moim/controller/MoimCalendarController.java
@@ -31,7 +31,7 @@ public class MoimCalendarController {
 
     @Operation(summary = "유저가 참여 신청한 모임 일정 조회", description = "유저가 참여 신청한 모임 일정들을 조회합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "COMMON200", description = "유저 일정 조회 성공"),
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
     })
     @GetMapping("/calender/user-moim-plans")
     public BaseResponse<PlanMonthListDTO<List<UserPlanDTO>>> getUserPlans(
@@ -42,26 +42,27 @@ public class MoimCalendarController {
         return BaseResponse.onSuccess(calenderQueryService.getUserPlans(user, year, month));
     }
 
-    @Operation(summary = "모임 일정 조회", description = "달력에서 특정 연도, 월에 등록되어 있는 일정들을 조회합니다. 모임에 참여하는 멤버만 조회 가능 합니다.")
+    @Operation(summary = "모임 (월) 일정 조회", description = "달력에서 특정 연도, 월에 등록되어 있는 일정들을 조회합니다. 모임에 참여하는 멤버만 조회 가능 합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "COMMON200", description = "모임 일정 조회 성공"),
-            @ApiResponse(responseCode = "MOIM_001", description = "모임을 찾을 수 없습니다.")
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @ApiResponse(responseCode = "MOIM_001", description = "모임을 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "MOIM_003", description = "모임의 멤버가 아닙니다.")
     })
     @GetMapping("/{moimId}/calender")
     public BaseResponse<PlanMonthListDTO<PlanDayListDTO>> getMoimPlans(
             @AuthUser User user,
-            @PathVariable Long moimId,
+            @UserMoimValidaton @MoimValidation @PathVariable Long moimId,
             @Parameter(description = "연도") @RequestParam int year,
             @Parameter(description = "월") @RequestParam int month
     ) {
         return BaseResponse.onSuccess(calenderQueryService.getMoimPlans(user, moimId, year, month));
     }
 
-    @Operation(summary = "모임 새로운 일정 생성", description = "모임의 새로운 일정을 추가합니다.")
+    @Operation(summary = "모임 일정 생성", description = "모임의 새로운 일정을 추가합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "COMMON201", description = "모임 새로운 일정 추가 성공"),
+            @ApiResponse(responseCode = "COMMON201", description = "요청 성공 및 리소스 생성됨"),
             @ApiResponse(responseCode = "MOIM_001", description = "모임을 찾을 수 없습니다."),
-            @ApiResponse(responseCode = "MOIM_002", description = "모임 관리자 회원이 아닙니다.")
+            @ApiResponse(responseCode = "MOIM_003", description = "모임의 멤버가 아닙니다.")
     })
     @PostMapping("/{moimId}/calender")
     public BaseResponse<Long> createPlan(
@@ -72,10 +73,12 @@ public class MoimCalendarController {
         return BaseResponse.onSuccess(calenderCommandService.createPlan(user, moimId, request));
     }
 
-    @Operation(summary = "모임 일정 세부사항 조회", description = "특정 일정의 상세 내용과 일정 스케줄을 조회합니다.")
+    @Operation(summary = "모임 특정 일정 세부사항 조회", description = "특정 일정의 상세 내용과 일정 스케줄을 조회합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "COMMON200", description = "모임 일정 상세 조회 성공"),
-            @ApiResponse(responseCode = "MOIM_001", description = "모임 정보를 찾을 수 없습니다.")
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @ApiResponse(responseCode = "MOIM_001", description = "모임을 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "MOIM_003", description = "모임의 멤버가 아닙니다."),
+            @ApiResponse(responseCode = "PLAN_005", description = "존재하지 않는 일정입니다.")
     })
     @GetMapping("/{moimId}/plan/{planId}")
     public BaseResponse<PlanDetailDTO> getPlanDetails(
@@ -87,10 +90,12 @@ public class MoimCalendarController {
         return BaseResponse.onSuccess(calenderQueryService.getPlanDetails(user, moimId, planId));
     }
 
-    @Operation(summary = "모임 일정 스케줄 상세 조회", description = "일정 스케줄들을 조회할 수 있습니다.")
+    @Operation(summary = "모임 일정 스케줄 리스트 조회", description = "특정 일정의 스케줄들을 조회할 수 있습니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "COMMON200", description = "모임 일정 상세 조회 성공"),
-            @ApiResponse(responseCode = "MOIM_001", description = "모임 정보를 찾을 수 없습니다.")
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @ApiResponse(responseCode = "MOIM_001", description = "모임을 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "MOIM_003", description = "모임의 멤버가 아닙니다."),
+            @ApiResponse(responseCode = "PLAN_005", description = "존재하지 않는 일정입니다.")
     })
     @GetMapping("/{moimId}/plan/{planId}/schedules")
     public BaseResponse<ScheduleListDTO> getSchedules(
@@ -100,14 +105,18 @@ public class MoimCalendarController {
         return BaseResponse.onSuccess(calenderQueryService.getSchedules(moimId, planId));
     }
 
-    @Operation(summary = "모임 일정 신청자 조회", description = "일정에 참가 신청한 사용자들을 조회합니다.")
+    @Operation(summary = "모임 일정 신청자 리스트 조회", description = "일정에 참가 신청한 사용자들을 조회합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "COMMON200", description = "모임 일정 상세 조회 성공"),
-            @ApiResponse(responseCode = "MOIM_001", description = "모임 정보를 찾을 수 없습니다.")
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @ApiResponse(responseCode = "MOIM_001", description = "모임을 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "MOIM_003", description = "모임의 멤버가 아닙니다."),
+            @ApiResponse(responseCode = "PLAN_005", description = "존재하지 않는 일정입니다."),
+            @ApiResponse(responseCode = "PAGE_003", description = "page 값이 유효하지 않습니다."),
+            @ApiResponse(responseCode = "PAGE_004", description = "size 값이 유효하지 않습니다.")
     })
     @GetMapping("/{moimId}/plan/{planId}/participants")
     public BaseResponse<PlanParticipantListPageDTO> getPlanParticipants(
-            @UserMoimValidaton @PathVariable Long moimId,
+            @UserMoimValidaton @MoimValidation @PathVariable Long moimId,
             @PlanValidation @PathVariable Long planId,
             @CheckPageValidation @RequestParam(name = "page") int page,
             @CheckSizeValidation @RequestParam(name = "size") int size
@@ -117,7 +126,11 @@ public class MoimCalendarController {
 
     @Operation(summary = "모임 일정 수정", description = "일정 작성자 유저, 모임장 유저만 일정을 수정할 수 있습니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @ApiResponse(responseCode = "MOIM_001", description = "모임을 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "MOIM_003", description = "모임의 멤버가 아닙니다."),
+            @ApiResponse(responseCode = "PLAN_005", description = "존재하지 않는 일정입니다."),
+            @ApiResponse(responseCode = "PLAN_006", description = "모임 일정 수정, 삭제 권한이 없는 유저입니다.")
     })
     @PutMapping("/{moimId}/plan/{planId}")
     public BaseResponse<?> updatePlan(
@@ -131,7 +144,11 @@ public class MoimCalendarController {
 
     @Operation(summary = "모임 일정 삭제", description = "일정 작성자 유저, 일정을 삭제할 수 있습니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @ApiResponse(responseCode = "MOIM_001", description = "모임을 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "MOIM_003", description = "모임의 멤버가 아닙니다."),
+            @ApiResponse(responseCode = "PLAN_005", description = "존재하지 않는 일정입니다."),
+            @ApiResponse(responseCode = "PLAN_006", description = "모임 일정 수정, 삭제 권한이 없는 유저입니다.")
     })
     @DeleteMapping("/{moimId}/plan/{planId}")
     public BaseResponse<?> deletePlan(
@@ -144,7 +161,11 @@ public class MoimCalendarController {
 
     @Operation(summary = "모임 일정 참여 신청", description = "모임 멤버가 특정 일정에 신청하는 기능입니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "COMMON201", description = "요청 성공 및 리소스 생성됨")
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @ApiResponse(responseCode = "MOIM_001", description = "모임을 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "MOIM_003", description = "모임의 멤버가 아닙니다."),
+            @ApiResponse(responseCode = "PLAN_005", description = "존재하지 않는 일정입니다."),
+            @ApiResponse(responseCode = "PLAN_003", description = "이미 해당 모임 일정에 참여 신청했습니다.")
     })
     @PostMapping("/{moimId}/plan/{planId}/participate")
     public BaseResponse<Long> joinPlan(
@@ -157,7 +178,12 @@ public class MoimCalendarController {
 
     @Operation(summary = "모임 일정 참여 신청 취소", description = "모임 멤버가 모임 일정 신청을 취소하는 기능입니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @ApiResponse(responseCode = "MOIM_001", description = "모임을 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "MOIM_003", description = "모임의 멤버가 아닙니다."),
+            @ApiResponse(responseCode = "PLAN_004", description = "해당 일정에 참여 신청하지 않았습니다."),
+            @ApiResponse(responseCode = "PLAN_005", description = "존재하지 않는 일정입니다.")
     })
     @DeleteMapping("/{moimId}/plan/{planId}/participate")
     public BaseResponse<?> cancelPlanParticipation(

--- a/src/main/java/com/dev/moim/domain/moim/dto/calender/PlanDetailDTO.java
+++ b/src/main/java/com/dev/moim/domain/moim/dto/calender/PlanDetailDTO.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 public record PlanDetailDTO(
         Long planId,
+        Long writerId,
         String title,
         LocalDateTime date,
         String location,
@@ -28,6 +29,7 @@ public record PlanDetailDTO(
 
         return new PlanDetailDTO(
                 plan.getId(),
+                plan.getUser().getId(),
                 plan.getTitle(),
                 plan.getDate(),
                 plan.getLocation(),

--- a/src/main/java/com/dev/moim/domain/moim/entity/IndividualPlan.java
+++ b/src/main/java/com/dev/moim/domain/moim/entity/IndividualPlan.java
@@ -24,6 +24,7 @@ public class IndividualPlan extends BaseEntity {
 
     private String title;
 
+    @Column(nullable = false)
     private LocalDateTime date;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/dev/moim/domain/moim/entity/Plan.java
+++ b/src/main/java/com/dev/moim/domain/moim/entity/Plan.java
@@ -1,5 +1,6 @@
 package com.dev.moim.domain.moim.entity;
 
+import com.dev.moim.domain.account.entity.User;
 import com.dev.moim.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -36,6 +37,10 @@ public class Plan extends BaseEntity {
     private String locationDetail;
 
     private String cost;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "moim_id")

--- a/src/main/java/com/dev/moim/domain/moim/entity/UserPlan.java
+++ b/src/main/java/com/dev/moim/domain/moim/entity/UserPlan.java
@@ -16,8 +16,6 @@ public class UserPlan extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Boolean isWriter;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;

--- a/src/main/java/com/dev/moim/domain/moim/repository/IndividualPlanRepository.java
+++ b/src/main/java/com/dev/moim/domain/moim/repository/IndividualPlanRepository.java
@@ -14,4 +14,6 @@ public interface IndividualPlanRepository extends JpaRepository<IndividualPlan, 
     List<IndividualPlan> findByUserIdAndDateBetween(Long userID, LocalDateTime startDate, LocalDateTime endDate);
 
     Slice<IndividualPlan> findByUserAndDateBetween(User user, LocalDateTime startOfDay, LocalDateTime endOfDay, Pageable pageable);
+
+    int countByUserAndDateBetween(User user, LocalDateTime startOfDay, LocalDateTime endOfDay);
 }

--- a/src/main/java/com/dev/moim/domain/moim/repository/PlanRepository.java
+++ b/src/main/java/com/dev/moim/domain/moim/repository/PlanRepository.java
@@ -19,4 +19,7 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
     Slice<Plan> findByUserAndDateBetween(User user, LocalDateTime startOfDay, LocalDateTime endOfDay, Pageable pageable);
 
     List<Plan> findByMoim(Moim moim);
+
+    @Query("SELECT COUNT(p) FROM UserPlan up JOIN up.plan p WHERE up.user = :user AND p.date BETWEEN :startOfDay AND :endOfDay")
+    int countByUserAndDateBetween(User user, LocalDateTime startOfDay, LocalDateTime endOfDay);
 }

--- a/src/main/java/com/dev/moim/domain/moim/repository/UserPlanRepository.java
+++ b/src/main/java/com/dev/moim/domain/moim/repository/UserPlanRepository.java
@@ -43,6 +43,4 @@ public interface UserPlanRepository extends JpaRepository<UserPlan, Long> {
                                                     Pageable pageable);
 
     Optional<UserPlan> findByUserIdAndPlanId(Long userId, Long planId);
-
-    Optional<UserPlan> findByPlanIdAndIsWriter(Long planId, boolean isWriter);
 }

--- a/src/main/java/com/dev/moim/domain/moim/service/impl/CalenderCommandServiceImpl.java
+++ b/src/main/java/com/dev/moim/domain/moim/service/impl/CalenderCommandServiceImpl.java
@@ -44,6 +44,7 @@ public class CalenderCommandServiceImpl implements CalenderCommandService {
                 .locationDetail(request.locationDetail())
                 .cost(request.cost())
                 .scheduleList(new ArrayList<>())
+                .user(user)
                 .moim(moim)
                 .build();
 
@@ -62,7 +63,6 @@ public class CalenderCommandServiceImpl implements CalenderCommandService {
         UserPlan userPlan = UserPlan.builder()
                 .user(user)
                 .plan(savedPlan)
-                .isWriter(true)
                 .build();
 
         userPlanRepository.save(userPlan);
@@ -77,7 +77,6 @@ public class CalenderCommandServiceImpl implements CalenderCommandService {
                 .orElseThrow(() -> new PlanException(PLAN_NOT_FOUND));
 
         UserPlan userPlan = UserPlan.builder()
-                .isWriter(false)
                 .user(user)
                 .plan(plan)
                 .build();

--- a/src/main/java/com/dev/moim/domain/moim/service/impl/CalenderCommandServiceImpl.java
+++ b/src/main/java/com/dev/moim/domain/moim/service/impl/CalenderCommandServiceImpl.java
@@ -58,16 +58,7 @@ public class CalenderCommandServiceImpl implements CalenderCommandService {
             });
         }
 
-        Plan savedPlan = planRepository.save(plan);
-
-        UserPlan userPlan = UserPlan.builder()
-                .user(user)
-                .plan(savedPlan)
-                .build();
-
-        userPlanRepository.save(userPlan);
-
-        return savedPlan.getId();
+        return planRepository.save(plan).getId();
     }
 
     @Override

--- a/src/main/java/com/dev/moim/domain/moim/service/impl/CalenderQueryServiceImpl.java
+++ b/src/main/java/com/dev/moim/domain/moim/service/impl/CalenderQueryServiceImpl.java
@@ -133,9 +133,9 @@ public class CalenderQueryServiceImpl implements CalenderQueryService {
 
     @Override
     public Long findPlanWriter(Long planId) {
-        UserPlan userPlan = userPlanRepository.findByPlanIdAndIsWriter(planId, true)
+        Plan plan = planRepository.findById(planId)
                 .orElseThrow(() -> new PlanException(PLAN_WRITER_NOT_FOUND));
 
-        return userPlan.getUser().getId();
+        return plan.getUser().getId();
     }
 }

--- a/src/main/java/com/dev/moim/domain/user/controller/UserController.java
+++ b/src/main/java/com/dev/moim/domain/user/controller/UserController.java
@@ -228,7 +228,19 @@ public class UserController {
         return BaseResponse.onSuccess(userQueryService.getUserDailyIndividualPlan(user, year, month, day, page, size));
     }
 
-
+    @Operation(summary = "특정 날짜 (유저의 총 일정 개수) 조회", description = "특정 날짜에 예정된 (유저의 총 일정 개수)를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
+    })
+    @GetMapping("/user-plan-count")
+    public BaseResponse<UserDailyPlanCntDTO> getUserDailyPlanCnt (
+            @AuthUser User user,
+            @Parameter(description = "연도") @RequestParam int year,
+            @Parameter(description = "월") @RequestParam int month,
+            @Parameter(description = "일") @RequestParam int day
+    ) {
+        return BaseResponse.onSuccess(userQueryService.getUserDailyPlanCnt(user, year, month, day));
+    }
   
     @Operation(summary = "이벤트 알림 발송", description = "모든 유저에게 이벤트 알림 발송을 합니다.")
     @ApiResponses({

--- a/src/main/java/com/dev/moim/domain/user/dto/UserDailyPlanCntDTO.java
+++ b/src/main/java/com/dev/moim/domain/user/dto/UserDailyPlanCntDTO.java
@@ -1,0 +1,7 @@
+package com.dev.moim.domain.user.dto;
+
+public record UserDailyPlanCntDTO(
+        String nickname,
+        int dailyPlanCnt
+) {
+}

--- a/src/main/java/com/dev/moim/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/dev/moim/domain/user/service/UserQueryService.java
@@ -4,10 +4,7 @@ import com.dev.moim.domain.account.entity.User;
 import com.dev.moim.domain.moim.dto.calender.PlanMonthListDTO;
 import com.dev.moim.domain.moim.dto.calender.UserDailyPlanPageDTO;
 import com.dev.moim.domain.moim.dto.calender.UserPlanDTO;
-import com.dev.moim.domain.user.dto.ChatRoomUserListResponse;
-import com.dev.moim.domain.user.dto.ProfileDTO;
-import com.dev.moim.domain.user.dto.ProfileDetailDTO;
-import com.dev.moim.domain.user.dto.ReviewListDTO;
+import com.dev.moim.domain.user.dto.*;
 
 import java.util.List;
 
@@ -24,6 +21,8 @@ public interface UserQueryService {
     UserDailyPlanPageDTO getUserDailyIndividualPlan(User user, int year, int month, int day, int page, int size);
 
     PlanMonthListDTO<List<UserPlanDTO>> getIndividualPlans(User user, int year, int month);
+
+    UserDailyPlanCntDTO getUserDailyPlanCnt(User user, int year, int month, int day);
 
     List<Long> findUserMoimIdListByUserId(Long userId);
 

--- a/src/main/java/com/dev/moim/domain/user/service/impl/UserQueryServiceImpl.java
+++ b/src/main/java/com/dev/moim/domain/user/service/impl/UserQueryServiceImpl.java
@@ -17,10 +17,8 @@ import com.dev.moim.domain.chatting.entity.ChatRoom;
 import com.dev.moim.domain.chatting.repository.ChatRoomRepository;
 import com.dev.moim.domain.moim.entity.UserMoim;
 import com.dev.moim.domain.moim.repository.UserMoimRepository;
-import com.dev.moim.domain.user.dto.ChatRoomUserListResponse;
-import com.dev.moim.domain.user.dto.ProfileDTO;
-import com.dev.moim.domain.user.dto.ProfileDetailDTO;
-import com.dev.moim.domain.user.dto.ReviewListDTO;
+import com.dev.moim.domain.moim.repository.UserPlanRepository;
+import com.dev.moim.domain.user.dto.*;
 import com.dev.moim.domain.user.service.UserQueryService;
 import com.dev.moim.global.error.handler.IndividualPlanException;
 import com.dev.moim.global.common.code.status.ErrorStatus;
@@ -39,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.dev.moim.domain.account.entity.enums.ProfileType.MAIN;
 import static com.dev.moim.domain.moim.entity.enums.MoimRole.OWNER;
@@ -57,6 +56,7 @@ public class UserQueryServiceImpl implements UserQueryService {
     private final IndividualPlanRepository individualPlanRepository;
     private final PlanRepository planRepository;
     private final ChatRoomRepository chatRoomRepository;
+    private final UserPlanRepository userPlanRepository;
 
     @Override
     public ProfileDTO getProfile(User user) {
@@ -121,6 +121,20 @@ public class UserQueryServiceImpl implements UserQueryService {
                 .collect(Collectors.groupingBy(dto -> dto.time().getDayOfMonth()));
 
         return new PlanMonthListDTO<>(monthPlanListByDay);
+    }
+
+    @Override
+    public UserDailyPlanCntDTO getUserDailyPlanCnt(User user, int year, int month, int day) {
+        LocalDateTime startOfDay = LocalDate.of(year, month, day).atStartOfDay();
+        LocalDateTime endOfDay = startOfDay.plusDays(1).minusNanos(1);
+
+        int individualPlanCnt = individualPlanRepository.countByUserAndDateBetween(user, startOfDay, endOfDay);
+        int moimPlanCnt = planRepository.countByUserAndDateBetween(user, startOfDay, endOfDay);
+
+        UserProfile userProfile = userProfileRepository.findByUserIdAndProfileType(user.getId(), MAIN)
+                .orElseThrow(() -> new UserException(USER_PROFILE_NOT_FOUND));
+
+        return new UserDailyPlanCntDTO(userProfile.getName(), individualPlanCnt + moimPlanCnt);
     }
 
     @Override

--- a/src/main/java/com/dev/moim/global/common/code/status/ErrorStatus.java
+++ b/src/main/java/com/dev/moim/global/common/code/status/ErrorStatus.java
@@ -53,12 +53,13 @@ public enum ErrorStatus implements BaseErrorCode {
     USER_UNREGISTERED(HttpStatus.UNAUTHORIZED, "AUTH_028", "존재하지 않는 계정입니다. 회원가입을 진행해주세요."),
     OIDC_PUBLIC_KEY_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH_029", "OIDC ID 토큰 공개키를 받아오는데 실패했습니다."),
 
-    // User 관련
-    INDIVIDUAL_PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_001", "존재하지 않는 개인 일정 입니다."),
-    NOT_INDIVIDUAL_PLAN_OWNER(HttpStatus.UNAUTHORIZED, "USER_002", "해당 일정의 작성자가 아닙니다."),
-    ALREADY_PARTICIPATE_IN_PLAN(HttpStatus.BAD_REQUEST, "USER_003", "이미 해당 모임 일정에 참여 신청했습니다."),
-    USER_NOT_PART_OF_PLAN(HttpStatus.BAD_REQUEST, "USER_004", "해당 일정에 참여 신청하지 않았습니다."),
-    IS_MOIM_OWNER(HttpStatus.BAD_REQUEST, "USER_005", "모임장 권한이 있는 유저입니다. 권한을 위임해주세요."),
+    // Plan 관련
+    INDIVIDUAL_PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN_001", "존재하지 않는 개인 일정 입니다."),
+    NOT_INDIVIDUAL_PLAN_OWNER(HttpStatus.UNAUTHORIZED, "PLAN_002", "해당 일정의 작성자가 아닙니다."),
+    ALREADY_PARTICIPATE_IN_PLAN(HttpStatus.BAD_REQUEST, "PLAN_003", "이미 해당 모임 일정에 참여 신청했습니다."),
+    USER_NOT_PART_OF_PLAN(HttpStatus.BAD_REQUEST, "PLAN_004", "해당 일정에 참여 신청하지 않았습니다."),
+    PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN_005", "존재하지 않는 일정입니다."),
+    PLAN_EDIT_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "PLAN_006", "모임 일정 수정, 삭제 권한이 없는 유저입니다." ),
 
     // Email 관련
     EMAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "EMAIL_001", "이메일 전송에 실패했습니다."),
@@ -70,13 +71,12 @@ public enum ErrorStatus implements BaseErrorCode {
     MOIM_NOT_FOUND(HttpStatus.NOT_FOUND, "MOIM_001", "모임을 찾을 수 없습니다."),
     MOIM_NOT_ADMIN(HttpStatus.UNAUTHORIZED, "MOIM_002", "모임 관리자 회원이 아닙니다."),
     INVALID_MOIM_MEMBER(HttpStatus.FORBIDDEN, "MOIM_003", "모임의 멤버가 아닙니다."),
-    PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "MOIM_004", "존재하지 않는 일정입니다."),
+    IS_MOIM_OWNER(HttpStatus.BAD_REQUEST, "MOIM_004", "모임장 권한이 있는 유저입니다. 권한을 위임해주세요."),
     PLAN_WRITER_NOT_FOUND(HttpStatus.NOT_FOUND, "MOIM_005", "해당 일정의 작성자를 찾을 수 없습니다."),
     USER_NOT_MOIM_JOIN(HttpStatus.UNAUTHORIZED, "MOIM_003", "모임의 회원이 아닙니다."),
     USER_NOT_MOIM_ADMIN(HttpStatus.FORBIDDEN, "MOIM_006", "모임의 관리자가 아닙니다."),
     VIDEO_ERROR(HttpStatus.NOT_FOUND, "MOIM_007", "해당 모임의 관리자가 없거나 관리자의 프로필이 존재하지 않습니다."),
     MOIM_OWNER_NOT_FOUND(HttpStatus.NOT_FOUND, "MOIM_008", "모임장 회원을 찾을 수 없습니다."),
-    PLAN_EDIT_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "MOIM_009", "모임 일정 수정, 삭제 권한이 없는 유저입니다ㅏ." ),
 
     // UserProfile 관련
     USER_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "USERPROFILE_001", "프로필을 찾을 수 없습니다."),


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #158

## 📌 개요
- 유저 특정 날짜 일정 개수 조회 기능 구현

## 🔁 변경 사항
✔️ 93d054704e7694b1b37d7e859619b67032eaf712 : Plan 엔티티에 작성자 User 엔티티 연관관계 추가

✔️ 105f9ce7c8f27d79e570533daee7cc006d488727 : User 관련 엔티티 정리
- nullable = false 추가

✔️ 4e16366669141fdb5aee662dc19358ad660c369e : 모임 일정 생성자 자동 참여 처리 변경
- 기존 로직 : 모임 일정 생성 시, 작성자 유저 자동으로 해당 일정 참여자로 등록
- 변경 로직 : 자동으로 참여자에 등록되지 않도록 처리

✔️ fe104f8498c16202d724ee05a0e62993328eb94c : 특정 날짜 유저 총 일정 개수 조회 기능 구현
- 특정 날짜 (연, 월, 일)에 유저의 총 일정 개수 (개인 일정 + 참여 신청한 모임 일정) 조회

✔️ f14a23f760ad1b28b0f152499c44facf1668da5c : 모임 일정 세부사항 조회 DTO 작성자 추가
- 일정 작성자 writerId 추가

✔️ 836c3fcf4c78364f55a6e5922b1ca8052c41e6c0 : 일정 관련 에러 정리
- ErrorStatus 정리
- MoimCalenderController 모임 관련 에러 스웨거 API 응답 정리


## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
