### PR TITLE
✨ Feature: fcmToken 검증 로직 추가

### DIFF
--- a/src/main/java/com/dev/moim/domain/account/dto/JoinRequest.java
+++ b/src/main/java/com/dev/moim/domain/account/dto/JoinRequest.java
@@ -2,13 +2,13 @@ package com.dev.moim.domain.account.dto;
 
 import com.dev.moim.domain.account.entity.enums.Gender;
 import com.dev.moim.domain.account.entity.enums.Provider;
+import com.dev.moim.global.validation.annotation.FcmTokenValidation;
 import com.dev.moim.global.validation.annotation.LocalAccountValidation;
 import com.dev.moim.global.validation.annotation.JoinPasswordValidation;
 import com.dev.moim.global.validation.annotation.OAuthAccountValidation;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import org.springframework.lang.NonNull;
 
 import java.time.LocalDate;
@@ -21,7 +21,7 @@ public record JoinRequest(
         @NonNull
         Provider provider,
         String providerId,
-        @NotBlank String fcmToken,
+        @FcmTokenValidation String fcmToken,
         @NotBlank
         String nickname,
         @NotBlank

--- a/src/main/java/com/dev/moim/global/firebase/service/FCMQueryService.java
+++ b/src/main/java/com/dev/moim/global/firebase/service/FCMQueryService.java
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
-public class FCMQueryService {
+public class FcmQueryService {
 
     public void isTokenValid(String sender, String token) {
         Notification notification = Notification.builder()

--- a/src/main/java/com/dev/moim/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/dev/moim/global/security/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import com.dev.moim.domain.account.repository.UserRepository;
 import com.dev.moim.domain.user.service.UserCommandService;
 import com.dev.moim.domain.user.service.UserQueryService;
 import com.dev.moim.global.common.code.status.SuccessStatus;
+import com.dev.moim.global.firebase.service.FcmQueryService;
 import com.dev.moim.global.redis.util.RedisUtil;
 import com.dev.moim.global.config.CorsConfig;
 import com.dev.moim.global.security.exception.JwtAccessDeniedHandler;
@@ -48,6 +49,7 @@ public class SecurityConfig {
     private final ApplicationEventPublisher eventPublisher;
     private final UserCommandService userCommandService;
     private final UserQueryService userQueryService;
+    private final FcmQueryService fcmQueryService;
 
     @Bean
     public AuthenticationManager authenticationManager() throws Exception {
@@ -119,11 +121,11 @@ public class SecurityConfig {
                 .anyRequest().permitAll());
 
         CustomLoginFilter customLoginFilter = new CustomLoginFilter(
-                authenticationManager(), jwtUtil, redisUtil, eventPublisher);
+                authenticationManager(), jwtUtil, redisUtil, eventPublisher, fcmQueryService);
         customLoginFilter.setFilterProcessesUrl("/api/v1/auth/login");
 
         OAuthLoginFilter oAuthLoginFilter = new OAuthLoginFilter(
-                jwtUtil, redisUtil, authenticationManager(), userRepository, eventPublisher);
+                jwtUtil, redisUtil, authenticationManager(), userRepository, eventPublisher, fcmQueryService);
 
         http.addFilterAt(customLoginFilter, UsernamePasswordAuthenticationFilter.class);
         http.addFilterAt(oAuthLoginFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/dev/moim/global/validation/annotation/FcmTokenValidation.java
+++ b/src/main/java/com/dev/moim/global/validation/annotation/FcmTokenValidation.java
@@ -1,0 +1,17 @@
+package com.dev.moim.global.validation.annotation;
+
+import com.dev.moim.global.validation.validator.FcmTokenValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = FcmTokenValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface FcmTokenValidation {
+    String message() default "FCM 토큰이 유효하지 않습니다..";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/dev/moim/global/validation/validator/FcmTokenValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/FcmTokenValidator.java
@@ -1,0 +1,48 @@
+package com.dev.moim.global.validation.validator;
+
+import com.dev.moim.global.common.code.status.ErrorStatus;
+import com.dev.moim.global.error.handler.AuthException;
+import com.dev.moim.global.firebase.service.FcmQueryService;
+import com.dev.moim.global.validation.annotation.FcmTokenValidation;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import static com.dev.moim.global.common.code.status.ErrorStatus.FCM_NOT_VALID;
+import static com.dev.moim.global.common.code.status.ErrorStatus.FCM_TOKEN_REQUIRED;
+
+@Component
+@RequiredArgsConstructor
+public class FcmTokenValidator implements ConstraintValidator<FcmTokenValidation, String> {
+
+    private final FcmQueryService fcmQueryService;
+
+    @Override
+    public void initialize(FcmTokenValidation constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(String fcmToken, ConstraintValidatorContext context) {
+
+        if (fcmToken == null || fcmToken.trim().isEmpty()) {
+            addConstraintViolation(context, FCM_TOKEN_REQUIRED);
+            return false;
+        }
+
+        try {
+            fcmQueryService.isTokenValid("MOIM", fcmToken);
+        } catch (AuthException e) {
+            addConstraintViolation(context, FCM_NOT_VALID);
+            return false;
+        }
+        return true;
+    }
+
+    private void addConstraintViolation(ConstraintValidatorContext context, ErrorStatus errorStatus) {
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate(errorStatus.toString())
+                .addConstraintViolation();
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #193

## 📌 개요
- fcmToken 유효성 검증 로직 추가

## 🔁 변경 사항
✔️ 71e34222a1a0f926a57ea0ca13cfd7660fff843e : 로그인 로직에 유효성 검증 로직 추가
- 일반 로그인 필터, 소셜 로그인 필터에서 유저 인증 성공 시, successfulAuthentication에서 fcmToken 유효성 검증 진행 후, accessToken, refreshToken 발급, 유저 fcmToken 업데이트 하도록 구현

✔️ 6123af271832d1346c842c9425563a038c6cc1b1 : 회원가입 로직에 유효성 검증 로직 추가
- DTO에서 fcmToken 검증하는 커스텀 어노테이션 구현, 적용

✔️ 1223305f606c9f5f301c27463c2542ae09711f3d : 로그인 로직 fcmToken 검증 순서 변경
- 일반 로그인 필터, 소셜 로그인 필터에서 유저 인증 진행 전, attemptAuthentication에서 fcmToken 유효성 검증 진행 후 유저 인증 진행하도록 변경

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
