### PR TITLE
✨ Feature: 특정 연, 월 유저의 일정 모든 타입 함께 조회

### DIFF
--- a/src/main/java/com/dev/moim/domain/moim/controller/MoimCalendarController.java
+++ b/src/main/java/com/dev/moim/domain/moim/controller/MoimCalendarController.java
@@ -4,7 +4,6 @@ import com.dev.moim.domain.account.entity.User;
 import com.dev.moim.domain.moim.dto.calender.*;
 import com.dev.moim.domain.moim.service.CalenderCommandService;
 import com.dev.moim.domain.moim.service.CalenderQueryService;
-import com.dev.moim.domain.user.dto.UserPlanDTO;
 import com.dev.moim.global.common.BaseResponse;
 import com.dev.moim.global.security.annotation.AuthUser;
 import com.dev.moim.global.validation.annotation.*;
@@ -18,8 +17,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @Validated
 @RestController
 @RequiredArgsConstructor
@@ -29,19 +26,6 @@ public class MoimCalendarController {
 
     private final CalenderCommandService calenderCommandService;
     private final CalenderQueryService calenderQueryService;
-
-    @Operation(summary = "유저가 참여 신청한 모임 일정 조회", description = "유저가 참여 신청한 모임 일정들을 조회합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
-    })
-    @GetMapping("/calender/user-moim-plans")
-    public BaseResponse<PlanMonthListDTO<List<UserPlanDTO>>> getUserPlans(
-            @AuthUser User user,
-            @Parameter(description = "연도") @RequestParam int year,
-            @Parameter(description = "월") @RequestParam int month
-    ) {
-        return BaseResponse.onSuccess(calenderQueryService.getUserPlans(user, year, month));
-    }
 
     @Operation(summary = "모임 (월) 일정 조회", description = "달력에서 특정 연도, 월에 등록되어 있는 일정들을 조회합니다. 모임에 참여하는 멤버만 조회 가능 합니다.")
     @ApiResponses(value = {

--- a/src/main/java/com/dev/moim/domain/moim/service/CalenderQueryService.java
+++ b/src/main/java/com/dev/moim/domain/moim/service/CalenderQueryService.java
@@ -2,13 +2,8 @@ package com.dev.moim.domain.moim.service;
 
 import com.dev.moim.domain.account.entity.User;
 import com.dev.moim.domain.moim.dto.calender.*;
-import com.dev.moim.domain.user.dto.UserPlanDTO;
-
-import java.util.List;
 
 public interface CalenderQueryService {
-
-    PlanMonthListDTO<List<UserPlanDTO>> getUserPlans(User user, int year, int month);
 
     PlanMonthListDTO<PlanDayListDTO> getMoimPlans(User user, Long moimId, int year, int month);
 

--- a/src/main/java/com/dev/moim/domain/moim/service/impl/CalenderQueryServiceImpl.java
+++ b/src/main/java/com/dev/moim/domain/moim/service/impl/CalenderQueryServiceImpl.java
@@ -9,7 +9,6 @@ import com.dev.moim.domain.moim.entity.UserPlan;
 import com.dev.moim.domain.moim.entity.enums.JoinStatus;
 import com.dev.moim.domain.moim.repository.*;
 import com.dev.moim.domain.moim.service.CalenderQueryService;
-import com.dev.moim.domain.user.dto.UserPlanDTO;
 import com.dev.moim.global.error.handler.MoimException;
 import com.dev.moim.global.error.handler.PlanException;
 import lombok.RequiredArgsConstructor;
@@ -41,21 +40,6 @@ public class CalenderQueryServiceImpl implements CalenderQueryService {
     private final UserPlanRepository userPlanRepository;
     private final ScheduleRepository scheduleRepository;
     private final UserMoimRepository userMoimRepository;
-
-    @Override
-    public PlanMonthListDTO<List<UserPlanDTO>> getUserPlans(User user, int year, int month) {
-        YearMonth yearMonth = YearMonth.of(year, month);
-        LocalDateTime startDate = yearMonth.atDay(1).atStartOfDay();
-        LocalDateTime endDate = yearMonth.atEndOfMonth().atTime(23, 59, 59);
-
-        List<UserPlan> userPlanList = userPlanRepository.findByUserIdAndPlanDateBetween(user.getId(), startDate, endDate);
-
-        Map<Integer, List<UserPlanDTO>> planListByDay = userPlanList.stream()
-                .map(userPlan -> UserPlanDTO.toUserMoimPlan(userPlan.getPlan()))
-                .collect(Collectors.groupingBy(dto -> dto.time().getDayOfMonth()));
-
-        return new PlanMonthListDTO<>(planListByDay);
-    }
 
     @Override
     public PlanMonthListDTO<PlanDayListDTO> getMoimPlans(User user, Long moimId, int year, int month) {

--- a/src/main/java/com/dev/moim/domain/user/controller/UserController.java
+++ b/src/main/java/com/dev/moim/domain/user/controller/UserController.java
@@ -189,13 +189,26 @@ public class UserController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "유저 일정 조회 성공"),
     })
-    @GetMapping("/calender")
+    @GetMapping("/monthly/individual-plan")
     public BaseResponse<PlanMonthListDTO<List<UserPlanDTO>>> getIndividualPlans(
             @AuthUser User user,
             @Parameter(description = "연도") @RequestParam int year,
             @Parameter(description = "월") @RequestParam int month
     ) {
         return BaseResponse.onSuccess(userQueryService.getIndividualPlans(user, year, month));
+    }
+
+    @Operation(summary = "특정 날짜 (연, 월) : 모든 타입 일정 조회", description = "유저의 모든 타입 일정 (참여 신청한 모임 일정 + 개인 일정) 을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "유저 일정 조회 성공"),
+    })
+    @GetMapping("/monthly/total-plan")
+    public BaseResponse<PlanMonthListDTO<List<UserPlanDTO>>> getUserMonthlyPlans(
+            @AuthUser User user,
+            @Parameter(description = "연도") @RequestParam int year,
+            @Parameter(description = "월") @RequestParam int month
+    ) {
+        return BaseResponse.onSuccess(userQueryService.getUserMonthlyPlans(user, year, month));
     }
 
     @Operation(summary = "특정 날짜 (연, 월, 일) : 유저가 참여 신청한 모임 일정 조회", description = "특정 날짜에 예정된 (유저가 참여 신청한 모임 일정)을 조회합니다.")

--- a/src/main/java/com/dev/moim/domain/user/controller/UserController.java
+++ b/src/main/java/com/dev/moim/domain/user/controller/UserController.java
@@ -185,11 +185,11 @@ public class UserController {
         return BaseResponse.onSuccess(null);
     }
 
-    @Operation(summary = "특정 날짜 (연, 월) : 개인 일정 조회", description = "유저의 개인 일정들을 조회합니다.")
+    @Operation(summary = "특정 날짜 (연, 월) : 개인 일정 리스트 조회", description = "유저의 개인 일정들을 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "유저 일정 조회 성공"),
     })
-    @GetMapping("/monthly/individual-plan")
+    @GetMapping("/monthly/individual-plans")
     public BaseResponse<PlanMonthListDTO<List<UserPlanDTO>>> getIndividualPlans(
             @AuthUser User user,
             @Parameter(description = "연도") @RequestParam int year,
@@ -198,11 +198,24 @@ public class UserController {
         return BaseResponse.onSuccess(userQueryService.getIndividualPlans(user, year, month));
     }
 
-    @Operation(summary = "특정 날짜 (연, 월) : 모든 타입 일정 조회", description = "유저의 모든 타입 일정 (참여 신청한 모임 일정 + 개인 일정) 을 조회합니다.")
+    @Operation(summary = "특정 날짜 (연, 월) : 유저가 참여 신청한 모임 일정 리스트 조회", description = "유저가 참여 신청한 모임 일정들을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
+    })
+    @GetMapping("/monthly/user-moim-plans")
+    public BaseResponse<PlanMonthListDTO<List<UserPlanDTO>>> getUserPlans(
+            @AuthUser User user,
+            @Parameter(description = "연도") @RequestParam int year,
+            @Parameter(description = "월") @RequestParam int month
+    ) {
+        return BaseResponse.onSuccess(userQueryService.getUserPlans(user, year, month));
+    }
+
+    @Operation(summary = "특정 날짜 (연, 월) : 모든 타입 일정 리스트 조회", description = "유저의 모든 타입 일정들 (참여 신청한 모임 일정 + 개인 일정) 을 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "유저 일정 조회 성공"),
     })
-    @GetMapping("/monthly/total-plan")
+    @GetMapping("/monthly/total-plans")
     public BaseResponse<PlanMonthListDTO<List<UserPlanDTO>>> getUserMonthlyPlans(
             @AuthUser User user,
             @Parameter(description = "연도") @RequestParam int year,
@@ -211,7 +224,7 @@ public class UserController {
         return BaseResponse.onSuccess(userQueryService.getUserMonthlyPlans(user, year, month));
     }
 
-    @Operation(summary = "특정 날짜 (연, 월, 일) : 유저가 참여 신청한 모임 일정 조회", description = "특정 날짜에 예정된 (유저가 참여 신청한 모임 일정)을 조회합니다.")
+    @Operation(summary = "특정 날짜 (연, 월, 일) : 유저가 참여 신청한 모임 일정 리스트 조회", description = "특정 날짜에 예정된 (유저가 참여 신청한 모임 일정)을 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
     })
@@ -227,7 +240,7 @@ public class UserController {
         return BaseResponse.onSuccess(userQueryService.getUserDailyMoimPlan(user, year, month, day, page, size));
     }
 
-    @Operation(summary = "특정 날짜 (연, 월, 일) : 유저의 개인 일정 조회", description = "특정 날짜에 예정된 (유저의 개인 일정)을 조회합니다.")
+    @Operation(summary = "특정 날짜 (연, 월, 일) : 유저의 개인 일정 리스트 조회", description = "특정 날짜에 예정된 (유저의 개인 일정)을 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
     })

--- a/src/main/java/com/dev/moim/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/dev/moim/domain/user/service/UserQueryService.java
@@ -2,8 +2,6 @@ package com.dev.moim.domain.user.service;
 
 import com.dev.moim.domain.account.entity.User;
 import com.dev.moim.domain.moim.dto.calender.PlanMonthListDTO;
-import com.dev.moim.domain.moim.entity.Moim;
-import com.dev.moim.domain.moim.entity.Post;
 import com.dev.moim.domain.user.dto.UserDailyPlanPageDTO;
 import com.dev.moim.domain.user.dto.UserPlanDTO;
 import com.dev.moim.domain.user.dto.*;
@@ -20,6 +18,8 @@ public interface UserQueryService {
     ReviewListDTO getUserReviews(Long userId, int page, int size);
 
     PlanMonthListDTO<List<UserPlanDTO>> getIndividualPlans(User user, int year, int month);
+
+    PlanMonthListDTO<List<UserPlanDTO>> getUserMonthlyPlans(User user, int year, int month);
 
     UserDailyPlanPageDTO getUserDailyMoimPlan(User user, int year, int month, int day, int page, int size);
 

--- a/src/main/java/com/dev/moim/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/dev/moim/domain/user/service/UserQueryService.java
@@ -19,6 +19,8 @@ public interface UserQueryService {
 
     PlanMonthListDTO<List<UserPlanDTO>> getIndividualPlans(User user, int year, int month);
 
+    PlanMonthListDTO<List<UserPlanDTO>> getUserPlans(User user, int year, int month);
+
     PlanMonthListDTO<List<UserPlanDTO>> getUserMonthlyPlans(User user, int year, int month);
 
     UserDailyPlanPageDTO getUserDailyMoimPlan(User user, int year, int month, int day, int page, int size);

--- a/src/main/java/com/dev/moim/domain/user/service/impl/UserQueryServiceImpl.java
+++ b/src/main/java/com/dev/moim/domain/user/service/impl/UserQueryServiceImpl.java
@@ -9,16 +9,12 @@ import com.dev.moim.domain.account.repository.UserProfileRepository;
 import com.dev.moim.domain.account.repository.UserRepository;
 import com.dev.moim.domain.account.repository.UserReviewRepository;
 import com.dev.moim.domain.moim.dto.calender.PlanMonthListDTO;
-import com.dev.moim.domain.moim.entity.Moim;
-import com.dev.moim.domain.moim.entity.Post;
-import com.dev.moim.domain.moim.entity.enums.JoinStatus;
+import com.dev.moim.domain.moim.entity.*;
 import com.dev.moim.domain.moim.entity.enums.PostType;
 import com.dev.moim.domain.moim.repository.*;
 import com.dev.moim.domain.moim.service.impl.dto.UserProfileDTO;
 import com.dev.moim.domain.user.dto.UserDailyPlanPageDTO;
 import com.dev.moim.domain.user.dto.UserPlanDTO;
-import com.dev.moim.domain.moim.entity.IndividualPlan;
-import com.dev.moim.domain.moim.entity.Plan;
 import com.dev.moim.domain.user.dto.*;
 import com.dev.moim.domain.user.service.UserQueryService;
 import com.dev.moim.global.common.code.status.ErrorStatus;
@@ -39,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.dev.moim.domain.account.entity.enums.ProfileType.MAIN;
 import static com.dev.moim.domain.moim.entity.enums.MoimRole.OWNER;
@@ -126,7 +123,6 @@ public class UserQueryServiceImpl implements UserQueryService {
 
     @Override
     public PlanMonthListDTO<List<UserPlanDTO>> getIndividualPlans(User user, int year, int month) {
-
         YearMonth yearMonth = YearMonth.of(year, month);
         LocalDateTime startDate = yearMonth.atDay(1).atStartOfDay();
         LocalDateTime endDate = yearMonth.atEndOfMonth().atTime(23, 59, 59);
@@ -138,6 +134,29 @@ public class UserQueryServiceImpl implements UserQueryService {
                 .collect(Collectors.groupingBy(dto -> dto.time().getDayOfMonth()));
 
         return new PlanMonthListDTO<>(monthPlanListByDay);
+    }
+
+    @Override
+    public PlanMonthListDTO<List<UserPlanDTO>> getUserMonthlyPlans(User user, int year, int month) {
+        YearMonth yearMonth = YearMonth.of(year, month);
+        LocalDateTime startDate = yearMonth.atDay(1).atStartOfDay();
+        LocalDateTime endDate = yearMonth.atEndOfMonth().atTime(23, 59, 59);
+
+        List<UserPlanDTO> userMoimPlanDTOList = userPlanRepository.findByUserIdAndPlanDateBetween(user.getId(), startDate, endDate).stream()
+                .map(userPlan -> UserPlanDTO.toUserMoimPlan(userPlan.getPlan()))
+                .toList();
+
+        List<UserPlanDTO> individualPlanDTOList = individualPlanRepository.findByUserIdAndDateBetween(user.getId(), startDate, endDate).stream()
+                .map(UserPlanDTO::toIndividualPlan)
+                .toList();
+
+        List<UserPlanDTO> userMonthlyPlanDTOList = Stream.concat(userMoimPlanDTOList.stream(), individualPlanDTOList.stream())
+                .toList();
+
+        Map<Integer, List<UserPlanDTO>> userMonthlyPlanListByDay = userMonthlyPlanDTOList.stream()
+                .collect(Collectors.groupingBy(plan -> plan.time().getDayOfMonth()));
+
+        return new PlanMonthListDTO<>(userMonthlyPlanListByDay);
     }
 
     @Override

--- a/src/main/java/com/dev/moim/domain/user/service/impl/UserQueryServiceImpl.java
+++ b/src/main/java/com/dev/moim/domain/user/service/impl/UserQueryServiceImpl.java
@@ -137,6 +137,21 @@ public class UserQueryServiceImpl implements UserQueryService {
     }
 
     @Override
+    public PlanMonthListDTO<List<UserPlanDTO>> getUserPlans(User user, int year, int month) {
+        YearMonth yearMonth = YearMonth.of(year, month);
+        LocalDateTime startDate = yearMonth.atDay(1).atStartOfDay();
+        LocalDateTime endDate = yearMonth.atEndOfMonth().atTime(23, 59, 59);
+
+        List<UserPlan> userPlanList = userPlanRepository.findByUserIdAndPlanDateBetween(user.getId(), startDate, endDate);
+
+        Map<Integer, List<UserPlanDTO>> planListByDay = userPlanList.stream()
+                .map(userPlan -> UserPlanDTO.toUserMoimPlan(userPlan.getPlan()))
+                .collect(Collectors.groupingBy(dto -> dto.time().getDayOfMonth()));
+
+        return new PlanMonthListDTO<>(planListByDay);
+    }
+
+    @Override
     public PlanMonthListDTO<List<UserPlanDTO>> getUserMonthlyPlans(User user, int year, int month) {
         YearMonth yearMonth = YearMonth.of(year, month);
         LocalDateTime startDate = yearMonth.atDay(1).atStartOfDay();


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #219 

## 📌 개요
- 특정 연, 월 유저의 일정 모든 타입 함께 조회

## 🔁 변경 사항
✔️ d20e08ea273f2d65f571b177e96e88f6f3ec4626 : 특정 월 유저의 모든 타입 일정 조회 기능 구현
- 유저가 참여 신청한 모임 일정 + 개인 일정 모두 조회

✔️ 7ec368077884dd74b6e99d8f935c1ed3e584ccba : 특정 월 유저의 참여 신청한 일정 조회 URI 변경
- /api/v1/users/monthly/user-moim-plans

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
