### PR TITLE
✨ Feature: deviceId가 null인 유저의 accessToken blackList에 추가

### DIFF
--- a/src/main/java/com/dev/moim/global/common/code/status/ErrorStatus.java
+++ b/src/main/java/com/dev/moim/global/common/code/status/ErrorStatus.java
@@ -52,6 +52,7 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_REQUEST_HEADER(HttpStatus.BAD_REQUEST, "AUTH_027", "잘못된 요청 헤더입니다."),
     USER_UNREGISTERED(HttpStatus.UNAUTHORIZED, "AUTH_028", "존재하지 않는 계정입니다. 회원가입을 진행해주세요."),
     OIDC_PUBLIC_KEY_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH_029", "OIDC ID 토큰 공개키를 받아오는데 실패했습니다."),
+    HTTP_REQUEST_NULL(HttpStatus.BAD_REQUEST, "AUTH_030", "HttpServletRequest가 null입니다."),
 
     // Plan 관련
     INDIVIDUAL_PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN_001", "존재하지 않는 개인 일정 입니다."),

--- a/src/main/java/com/dev/moim/global/security/annotation/AuthUserArgumentResolver.java
+++ b/src/main/java/com/dev/moim/global/security/annotation/AuthUserArgumentResolver.java
@@ -3,10 +3,13 @@ package com.dev.moim.global.security.annotation;
 import com.dev.moim.domain.account.entity.User;
 import com.dev.moim.domain.account.repository.UserRepository;
 import com.dev.moim.global.error.handler.AuthException;
+import com.dev.moim.global.redis.util.RedisUtil;
+import com.dev.moim.global.security.util.JwtUtil;
 import jakarta.annotation.Nonnull;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -14,13 +17,19 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-import static com.dev.moim.global.common.code.status.ErrorStatus.AUTH_INVALID_TOKEN;
+import java.util.Date;
+import java.util.Optional;
 
+import static com.dev.moim.global.common.code.status.ErrorStatus.*;
+
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
 
     private final UserRepository userRepository;
+    private final RedisUtil redisUtil;
+    private final JwtUtil jwtUtil;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -34,13 +43,29 @@ public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
             @Nonnull NativeWebRequest webRequest,
             WebDataBinderFactory binderFactory)
             throws Exception {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        if (authentication != null) {
-            String userId = authentication.getName();
-            return userRepository.findById(Long.valueOf(userId))
-                    .orElseThrow(() -> new AuthException(AUTH_INVALID_TOKEN));
+        HttpServletRequest httpServletRequest = webRequest.getNativeRequest(HttpServletRequest.class);
+
+        if (httpServletRequest == null) {
+            throw new AuthException(HTTP_REQUEST_NULL);
         }
-        return null;
+
+        String accessToken = jwtUtil.resolveToken(httpServletRequest);
+
+        return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
+                .map(authentication -> {
+                    String userId = authentication.getName();
+                    User user = userRepository.findById(Long.valueOf(userId))
+                            .orElseThrow(() -> new AuthException(USER_NOT_FOUND));
+
+                    if (user.getDeviceId() == null) {
+                        Long now = new Date().getTime();
+                        Long expiration = jwtUtil.getExpiration(accessToken) - now;
+                        redisUtil.setValue(accessToken, "deviceId_missing", expiration);
+
+                        throw new AuthException(FCM_TOKEN_REQUIRED);
+                    }
+                    return user;
+                }).orElseThrow(() -> new AuthException(AUTH_INVALID_TOKEN));
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #241

## 📌 개요
- deviceId가 null인 유저의 accessToken blackList에 추가

## 🔁 변경 사항
✔️ d47b7cb4b9331cd79746ee37ccf806f4ea06abbf : deviceId가 null인 유저 처리
- @AuthUser에서 유저 추출 시, deviceId가 있는지 검증하고 없는 경우 blackList에 추가


## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
