### PR TITLE
✨ Featre: 특정 날짜에 예정된 유저의 총 일정 개수에 todo 개수 포함

### DIFF
--- a/src/main/java/com/dev/moim/domain/moim/repository/UserTodoRepository.java
+++ b/src/main/java/com/dev/moim/domain/moim/repository/UserTodoRepository.java
@@ -1,5 +1,6 @@
 package com.dev.moim.domain.moim.repository;
 
+import com.dev.moim.domain.account.entity.User;
 import com.dev.moim.domain.moim.entity.UserTodo;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -7,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface UserTodoRepository extends JpaRepository<UserTodo, Long> {
@@ -27,4 +29,13 @@ public interface UserTodoRepository extends JpaRepository<UserTodo, Long> {
             @Param("todoId") Long todoId,
             @Param("cursor") Long cursor,
             Pageable pageable);
+
+    @Query("SELECT COUNT(ut) " +
+            "FROM UserTodo ut " +
+            "JOIN ut.todo t " +
+            "WHERE ut.user = :user " +
+            "AND t.dueDate BETWEEN :startOfDay AND :endOfDay")
+    int countByUserAndTodoDueDateBetween(@Param("user") User user,
+                                         @Param("startOfDay") LocalDateTime startOfDay,
+                                         @Param("endOfDay") LocalDateTime endOfDay);
 }

--- a/src/main/java/com/dev/moim/domain/user/controller/UserController.java
+++ b/src/main/java/com/dev/moim/domain/user/controller/UserController.java
@@ -260,7 +260,7 @@ public class UserController {
         return BaseResponse.onSuccess(userQueryService.getUserDailyIndividualPlans(user, year, month, day, page, size));
     }
 
-    @Operation(summary = "특정 날짜 (연, 월, 일) : 유저의 (개인 + 모임 신청 일정) 리스트 조회", description = "특정 날짜에 예정된 (개인 + 모임 신청 일정) 리스트를 조회합니다.")
+    @Operation(summary = "특정 날짜 (연, 월, 일) : 유저의 (개인 일정 + 모임 신청 일정 + 할당받은 todo) 리스트 조회", description = "특정 날짜에 예정된 (개인 + 모임 신청 일정) 리스트를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
     })
@@ -276,7 +276,7 @@ public class UserController {
         return BaseResponse.onSuccess(userQueryService.getUserDailyPlans(user, year, month, day, page, size));
     }
 
-    @Operation(summary = "특정 날짜 (연, 월, 일) : 유저의 총 일정 개수 조회", description = "특정 날짜에 예정된 (유저의 총 일정 개수)를 조회합니다.")
+    @Operation(summary = "특정 날짜 (연, 월, 일) : 유저의 총 일정 개수 조회", description = "특정 날짜에 예정된 유저의 총 일정 개수 (개인 일정 + 모임 신청 일정 + 할당받은 todo) 를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "성공입니다.")
     })

--- a/src/main/java/com/dev/moim/domain/user/service/impl/UserQueryServiceImpl.java
+++ b/src/main/java/com/dev/moim/domain/user/service/impl/UserQueryServiceImpl.java
@@ -55,7 +55,7 @@ public class UserQueryServiceImpl implements UserQueryService {
     private final UserPlanRepository userPlanRepository;
     private final MoimRepository moimRepository;
     private final PostRepository postRepository;
-    private final UserCommandService userCommandService;
+    private final UserTodoRepository userTodoRepository;
 
     @Override
     public ProfileDTO getProfile(User user) {
@@ -174,11 +174,12 @@ public class UserQueryServiceImpl implements UserQueryService {
 
         int individualPlanCnt = individualPlanRepository.countByUserAndDateBetween(user, startOfDay, endOfDay);
         int moimPlanCnt = userPlanRepository.countPlansByUserAndDateBetween(user, startOfDay, endOfDay);
+        int todoPlanCnt = userTodoRepository.countByUserAndTodoDueDateBetween(user, startOfDay, endOfDay);
 
         UserProfile userProfile = userProfileRepository.findByUserIdAndProfileType(user.getId(), MAIN)
                 .orElseThrow(() -> new UserException(USER_PROFILE_NOT_FOUND));
 
-        return new UserDailyPlanCntDTO(userProfile.getName(), individualPlanCnt + moimPlanCnt);
+        return new UserDailyPlanCntDTO(userProfile.getName(), individualPlanCnt + moimPlanCnt + todoPlanCnt);
     }
 
     @Override


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #281

## 📌 개요
- 특정 날짜에 예정된 유저의 총 일정 개수에 todo 개수 포함

## 🔁 변경 사항
✔️ bb0daa8d5ecd9d470bcb25aef8f8edae79c95a49 : 특정 날짜 유저 일정 cnt에 todo 포함
- todo 기능이 추가되면서, 특정 날짜 (연, 월, 일)에 예정된 로그인된 유저의 일정 개수를 조회할 때, 유저가 할당받은 todo 중 dueDate가 해당 날짜로 설정된 todo의 개수도 포함하도록 수정했습니다.


## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
