### PR TITLE
🐛 Fix: 알림 전송 대상에 자신도 포함된 경우 처리

### DIFF
--- a/src/main/java/com/dev/moim/domain/moim/controller/MoimCalendarController.java
+++ b/src/main/java/com/dev/moim/domain/moim/controller/MoimCalendarController.java
@@ -119,11 +119,12 @@ public class MoimCalendarController {
     })
     @PutMapping("/{moimId}/plan/{planId}")
     public BaseResponse<?> updatePlan(
+            @AuthUser User user,
             @UserMoimValidaton @PathVariable Long moimId,
             @PlanAuthorityValidation @PathVariable Long planId,
             @RequestBody PlanCreateDTO request
     ) {
-        calenderCommandService.updatePlan(moimId, planId, request);
+        calenderCommandService.updatePlan(user, moimId, planId, request);
         return BaseResponse.onSuccess(null);
     }
 
@@ -137,10 +138,11 @@ public class MoimCalendarController {
     })
     @DeleteMapping("/{moimId}/plan/{planId}")
     public BaseResponse<?> deletePlan(
+            @AuthUser User user,
             @UserMoimValidaton @PathVariable Long moimId,
             @PlanAuthorityValidation @PathVariable Long planId
     ) {
-        calenderCommandService.deletePlan(moimId, planId);
+        calenderCommandService.deletePlan(user, moimId, planId);
         return BaseResponse.onSuccess(null);
     }
 

--- a/src/main/java/com/dev/moim/domain/moim/service/CalenderCommandService.java
+++ b/src/main/java/com/dev/moim/domain/moim/service/CalenderCommandService.java
@@ -11,7 +11,7 @@ public interface CalenderCommandService {
 
     void cancelPlanParticipation(User user, Long moidId, Long planId);
 
-    void updatePlan(Long moimId, Long planId, PlanCreateDTO request);
+    void updatePlan(User user, Long moimId, Long planId, PlanCreateDTO request);
 
-    void deletePlan(Long moimId, Long planId);
+    void deletePlan(User user, Long moimId, Long planId);
 }

--- a/src/main/java/com/dev/moim/domain/moim/service/impl/TodoCommandServiceImpl.java
+++ b/src/main/java/com/dev/moim/domain/moim/service/impl/TodoCommandServiceImpl.java
@@ -83,7 +83,9 @@ public class TodoCommandServiceImpl implements TodoCommandService {
 
         userTodoRepository.saveAll(userTodoList);
 
-        userList.forEach(assignee -> {
+        userList.stream().filter(assignee -> !user.equals(assignee))
+                .forEach(assignee -> {
+
             alarmService.saveAlarm(user, assignee, "[" + moim.getName() + "] 새로운 todo를 받았습니다", todo.getTitle(), AlarmType.PUSH, AlarmDetailType.TODO, moim.getId(), null, null);
 
             if (assignee.getIsPushAlarm() && assignee.getDeviceId() != null) {


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #285

## 📌 개요
- 모임의 todo를 생성할 때, todo를 할당받을 assignee에 작성자 자신도 포함한 케이스에 대한 처리가 이루어지지 않았었습니다. 따라서 todo 생성 요청 시, todo 생성, userTodo 생성 및 알림 생성은 되지만, 작성자의 user 테이블에서 deviceId가 null 처리되는 버그가 발생했습니다. 따라서 이때 deviceId가 null이 되면서, 이후 요청이 들어올 때, @authuser에서 deviceId가 null인지 검증하는 과정에서 예외가 발생하게 되고, 해당 accessToken이 blackList에 등록되면서 이후 요청이 막히게 됐습니다. 따라서 버그를 해결하고자 알림 전송 대상에 유저 자신도 포함된 경우에 대한 처리를 추가했습니다.

## 🔁 변경 사항
✔️ 569fa511de7b3a7bad7b6b43693060865dfbcb37 : 알림 전송 대상에 자신도 포함된 경우 처리

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
