### PR TITLE
✨ Feature: exceptionAdvice 에러 처리 정리

### DIFF
--- a/src/main/java/com/dev/moim/domain/moim/controller/MoimTodoController.java
+++ b/src/main/java/com/dev/moim/domain/moim/controller/MoimTodoController.java
@@ -29,6 +29,7 @@ public class MoimTodoController {
     @Operation(summary = "모임 todo 생성", description = "모임 관리자 회원이 모임의 멤버들에게 todo를 줄 수 있는 기능입니다. 관리자 회원만 가능합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @ApiResponse(responseCode = "COMMON_002", description = "입력된 정보에 오류가 있습니다. 필드별 오류 메시지를 참조하세요."),
             @ApiResponse(responseCode = "MOIM_002", description = "모임 관리자 회원이 아닙니다."),
             @ApiResponse(responseCode = "MOIM_003", description = "모임의 멤버가 아닙니다."),
             @ApiResponse(responseCode = "TODO_004", description = "Todo를 할당받을 유저를 지정하지 않았습니다."),
@@ -156,6 +157,7 @@ public class MoimTodoController {
     @Operation(summary = "부여된 todo 상태 업데이트", description = "회원이 자신에게 부여된 todo의 상태를 변경합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @ApiResponse(responseCode = "COMMON_002", description = "입력된 정보에 오류가 있습니다. 필드별 오류 메시지를 참조하세요."),
             @ApiResponse(responseCode = "MOIM_003", description = "모임의 멤버가 아닙니다."),
             @ApiResponse(responseCode = "TODO_001", description = "Todo를 찾을 수 없습니다."),
             @ApiResponse(responseCode = "TODO_002", description = "해당 유저에게 부여된 todo가 아닙니다."),
@@ -176,6 +178,7 @@ public class MoimTodoController {
     @Operation(summary = "todo 수정", description = "모임 관리자 회원이 특정 todo 내용을 수정합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @ApiResponse(responseCode = "COMMON_002", description = "입력된 정보에 오류가 있습니다. 필드별 오류 메시지를 참조하세요."),
             @ApiResponse(responseCode = "MOIM_002", description = "모임 관리자 회원이 아닙니다."),
             @ApiResponse(responseCode = "MOIM_003", description = "모임의 멤버가 아닙니다."),
             @ApiResponse(responseCode = "TODO_001", description = "Todo를 찾을 수 없습니다."),
@@ -213,6 +216,7 @@ public class MoimTodoController {
     @Operation(summary = "todo assignee 추가", description = "모임 관리자 회원이 특정 todo를 할당받을 모임 멤버를 추가합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @ApiResponse(responseCode = "COMMON_002", description = "입력된 정보에 오류가 있습니다. 필드별 오류 메시지를 참조하세요."),
             @ApiResponse(responseCode = "MOIM_002", description = "모임 관리자 회원이 아닙니다."),
             @ApiResponse(responseCode = "MOIM_003", description = "모임의 멤버가 아닙니다."),
             @ApiResponse(responseCode = "TODO_001", description = "Todo를 찾을 수 없습니다."),
@@ -230,6 +234,7 @@ public class MoimTodoController {
     @Operation(summary = "todo assignee 삭제", description = "모임 관리자 회원이 특정 todo를 할당받을 모임 멤버를 삭제합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "COMMON200", description = "성공입니다."),
+            @ApiResponse(responseCode = "COMMON_002", description = "입력된 정보에 오류가 있습니다. 필드별 오류 메시지를 참조하세요."),
             @ApiResponse(responseCode = "MOIM_002", description = "모임 관리자 회원이 아닙니다."),
             @ApiResponse(responseCode = "MOIM_003", description = "모임의 멤버가 아닙니다."),
             @ApiResponse(responseCode = "TODO_001", description = "Todo를 찾을 수 없습니다."),

--- a/src/main/java/com/dev/moim/domain/moim/dto/todo/UpdateTodoStatusDTO.java
+++ b/src/main/java/com/dev/moim/domain/moim/dto/todo/UpdateTodoStatusDTO.java
@@ -2,10 +2,11 @@ package com.dev.moim.domain.moim.dto.todo;
 
 import com.dev.moim.domain.moim.entity.enums.TodoAssigneeStatus;
 import com.dev.moim.global.validation.annotation.TodoAssigneeStatusValidation;
+import com.dev.moim.global.validation.annotation.TodoAssigneeValidation;
 
 @TodoAssigneeStatusValidation
 public record UpdateTodoStatusDTO(
-        Long todoId,
+        @TodoAssigneeValidation Long todoId,
         TodoAssigneeStatus todoAssigneeStatus
 ) {
 }

--- a/src/main/java/com/dev/moim/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/dev/moim/domain/user/service/UserQueryService.java
@@ -3,6 +3,7 @@ package com.dev.moim.domain.user.service;
 import com.dev.moim.domain.account.entity.User;
 import com.dev.moim.domain.account.entity.enums.Provider;
 import com.dev.moim.domain.moim.dto.calender.PlanMonthListDTO;
+import com.dev.moim.domain.moim.entity.IndividualPlan;
 import com.dev.moim.domain.user.dto.UserDailyPlanPageDTO;
 import com.dev.moim.domain.user.dto.UserPlanDTO;
 import com.dev.moim.domain.user.dto.*;
@@ -36,7 +37,7 @@ public interface UserQueryService {
 
     List<Long> findUserMoimIdListByUserId(Long userId);
 
-    Long findUserByPlanId(Long individualPlanId);
+    Optional<IndividualPlan> findUserByPlanId(Long individualPlanId);
 
     boolean isExistEmail(String email);
 

--- a/src/main/java/com/dev/moim/domain/user/service/impl/UserQueryServiceImpl.java
+++ b/src/main/java/com/dev/moim/domain/user/service/impl/UserQueryServiceImpl.java
@@ -16,7 +16,6 @@ import com.dev.moim.domain.moim.service.impl.dto.UserProfileDTO;
 import com.dev.moim.domain.user.dto.UserDailyPlanPageDTO;
 import com.dev.moim.domain.user.dto.UserPlanDTO;
 import com.dev.moim.domain.user.dto.*;
-import com.dev.moim.domain.user.service.UserCommandService;
 import com.dev.moim.domain.user.service.UserQueryService;
 import com.dev.moim.global.common.code.status.ErrorStatus;
 import com.dev.moim.global.error.handler.*;
@@ -206,11 +205,8 @@ public class UserQueryServiceImpl implements UserQueryService {
     }
 
     @Override
-    public Long findUserByPlanId(Long individualPlanId) {
-        IndividualPlan individualPlan = individualPlanRepository.findById(individualPlanId)
-                .orElseThrow(() -> new IndividualPlanException(INDIVIDUAL_PLAN_NOT_FOUND));
-
-        return individualPlan.getUser().getId();
+    public Optional<IndividualPlan> findUserByPlanId(Long individualPlanId) {
+        return individualPlanRepository.findById(individualPlanId);
     }
 
     @Override

--- a/src/main/java/com/dev/moim/global/common/code/status/ErrorStatus.java
+++ b/src/main/java/com/dev/moim/global/common/code/status/ErrorStatus.java
@@ -16,7 +16,10 @@ public enum ErrorStatus implements BaseErrorCode {
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
     // 공통 에러
-    PAGE_UNDER_ZERO(HttpStatus.BAD_REQUEST, "COMM_001", "페이지는 0이상이어야 합니다."),
+    PAGE_UNDER_ZERO(HttpStatus.BAD_REQUEST, "COMMON_001", "페이지는 0이상이어야 합니다."),
+    MULTIPLE_FIELD_VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "COMMON_002", "입력된 정보에 오류가 있습니다. 필드별 오류 메시지를 참조하세요."),
+    NO_MATCHING_ERROR_STATUS(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_003", "서버 에러. 일치하는 errorStatus를 찾을 수 없습니다."),
+    REQUEST_BODY_INVALID(HttpStatus.BAD_REQUEST, "COMMON_004", "요청 본문을 읽을 수 없습니다. 빈 문자열 또는 null이 있는지 확인해주세요."),
 
     // S3 관련
     S3_OBJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "S3_001", "S3 오브젝트를 찾을 수 없습니다."),

--- a/src/main/java/com/dev/moim/global/validation/validator/CheckAdminValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/CheckAdminValidator.java
@@ -36,9 +36,7 @@ public class CheckAdminValidator implements ConstraintValidator<CheckAdminValida
 
         if (userMoim.isEmpty()) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(INVALID_MOIM_MEMBER.toString())
-                    .addPropertyNode("userId")
-                    .addPropertyNode("moimId")
+            context.buildConstraintViolationWithTemplate(INVALID_MOIM_MEMBER.getMessage())
                     .addConstraintViolation();
             return false;
         } else {
@@ -46,9 +44,7 @@ public class CheckAdminValidator implements ConstraintValidator<CheckAdminValida
                 return true;
             } else {
                 context.disableDefaultConstraintViolation();
-                context.buildConstraintViolationWithTemplate(MOIM_NOT_ADMIN.toString())
-                        .addPropertyNode("userId")
-                        .addPropertyNode("moimId")
+                context.buildConstraintViolationWithTemplate(MOIM_NOT_ADMIN.getMessage())
                         .addConstraintViolation();
                 return false;
             }

--- a/src/main/java/com/dev/moim/global/validation/validator/CheckCursorValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/CheckCursorValidator.java
@@ -19,7 +19,7 @@ public class CheckCursorValidator implements ConstraintValidator<CheckCursorVali
     public boolean isValid(Long value, ConstraintValidatorContext context) {
         if (value <= 0) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(ErrorStatus.NOT_VALID_CURSOR.toString())
+            context.buildConstraintViolationWithTemplate(ErrorStatus.NOT_VALID_CURSOR.getMessage())
                     .addConstraintViolation();
 
             return false;

--- a/src/main/java/com/dev/moim/global/validation/validator/CheckPageValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/CheckPageValidator.java
@@ -20,7 +20,7 @@ public class CheckPageValidator implements ConstraintValidator<CheckPageValidati
     public boolean isValid(Integer value, ConstraintValidatorContext context) {
         if (value <= 0) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(NOT_VALID_PAGE.toString())
+            context.buildConstraintViolationWithTemplate(NOT_VALID_PAGE.getMessage())
                     .addConstraintViolation();
 
             return false;

--- a/src/main/java/com/dev/moim/global/validation/validator/CheckSizeValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/CheckSizeValidator.java
@@ -20,7 +20,7 @@ public class CheckSizeValidator implements ConstraintValidator<CheckSizeValidati
     public boolean isValid(Integer value, ConstraintValidatorContext context) {
         if (value <= 0) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(NOT_VALID_SIZE.toString())
+            context.buildConstraintViolationWithTemplate(NOT_VALID_SIZE.getMessage())
                     .addConstraintViolation();
 
             return false;

--- a/src/main/java/com/dev/moim/global/validation/validator/CheckTakeValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/CheckTakeValidator.java
@@ -19,7 +19,7 @@ public class CheckTakeValidator implements ConstraintValidator<CheckTakeValidati
     public boolean isValid(Integer value, ConstraintValidatorContext context) {
         if (value <= 0) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(ErrorStatus.NOT_VALID_TAKE.toString())
+            context.buildConstraintViolationWithTemplate(ErrorStatus.NOT_VALID_TAKE.getMessage())
                     .addConstraintViolation();
 
             return false;

--- a/src/main/java/com/dev/moim/global/validation/validator/ExistEmailValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/ExistEmailValidator.java
@@ -26,7 +26,7 @@ public class ExistEmailValidator implements ConstraintValidator<ExistEmailValida
 
         if (!isExistEmail){
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(USER_NOT_FOUND.toString())
+            context.buildConstraintViolationWithTemplate(USER_NOT_FOUND.getMessage())
                     .addPropertyNode("email")
                     .addConstraintViolation();
             return false;

--- a/src/main/java/com/dev/moim/global/validation/validator/ExistEmailValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/ExistEmailValidator.java
@@ -27,7 +27,6 @@ public class ExistEmailValidator implements ConstraintValidator<ExistEmailValida
         if (!isExistEmail){
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate(USER_NOT_FOUND.getMessage())
-                    .addPropertyNode("email")
                     .addConstraintViolation();
             return false;
         }

--- a/src/main/java/com/dev/moim/global/validation/validator/ExistUserValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/ExistUserValidator.java
@@ -29,7 +29,7 @@ public class ExistUserValidator implements ConstraintValidator<ExistUserValidati
 
         if (user.isEmpty()){
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(USER_NOT_FOUND.toString())
+            context.buildConstraintViolationWithTemplate(USER_NOT_FOUND.getMessage())
                     .addPropertyNode("userId")
                     .addConstraintViolation();
             return false;

--- a/src/main/java/com/dev/moim/global/validation/validator/ExistUserValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/ExistUserValidator.java
@@ -30,7 +30,6 @@ public class ExistUserValidator implements ConstraintValidator<ExistUserValidati
         if (user.isEmpty()){
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate(USER_NOT_FOUND.getMessage())
-                    .addPropertyNode("userId")
                     .addConstraintViolation();
             return false;
         }

--- a/src/main/java/com/dev/moim/global/validation/validator/FcmTokenValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/FcmTokenValidator.java
@@ -26,14 +26,14 @@ public class FcmTokenValidator implements ConstraintValidator<FcmTokenValidation
     public boolean isValid(String fcmToken, ConstraintValidatorContext context) {
 
         if (fcmToken == null || fcmToken.trim().isEmpty()) {
-            addConstraintViolation(context, FCM_TOKEN_REQUIRED.toString());
+            addConstraintViolation(context, FCM_TOKEN_REQUIRED.getMessage());
             return false;
         }
 
         try {
             fcmQueryService.isTokenValid("MOIM", fcmToken);
         } catch (AuthException e) {
-            addConstraintViolation(context, FCM_NOT_VALID.toString());
+            addConstraintViolation(context, FCM_NOT_VALID.getMessage());
             return false;
         }
         return true;

--- a/src/main/java/com/dev/moim/global/validation/validator/JoinPasswordValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/JoinPasswordValidator.java
@@ -24,7 +24,6 @@ public class JoinPasswordValidator implements ConstraintValidator<JoinPasswordVa
     @Override
     public boolean isValid(JoinRequest request, ConstraintValidatorContext context) {
         if (request.provider() == LOCAL && !isPasswordValid(request.password(), context)) {
-            log.warn("회원가입 실패 : 비밀번호 조건 미충족");
             return false;
         }
         return true;
@@ -36,7 +35,6 @@ public class JoinPasswordValidator implements ConstraintValidator<JoinPasswordVa
         if (password == null || !password.matches(passwordPattern)) {
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate(INVALID_PASSWORD.getMessage())
-                    .addPropertyNode("password")
                     .addConstraintViolation();
             return false;
         }

--- a/src/main/java/com/dev/moim/global/validation/validator/JoinPasswordValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/JoinPasswordValidator.java
@@ -35,7 +35,7 @@ public class JoinPasswordValidator implements ConstraintValidator<JoinPasswordVa
 
         if (password == null || !password.matches(passwordPattern)) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(INVALID_PASSWORD.toString())
+            context.buildConstraintViolationWithTemplate(INVALID_PASSWORD.getMessage())
                     .addPropertyNode("password")
                     .addConstraintViolation();
             return false;

--- a/src/main/java/com/dev/moim/global/validation/validator/LocalAccountValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/LocalAccountValidator.java
@@ -33,7 +33,7 @@ public class LocalAccountValidator implements ConstraintValidator<LocalAccountVa
     private boolean validateEmailDuplication(String email, ConstraintValidatorContext context) {
         if (userQueryService.existsByEmail(email)) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(EMAIL_DUPLICATION.toString())
+            context.buildConstraintViolationWithTemplate(EMAIL_DUPLICATION.getMessage())
                     .addPropertyNode("email")
                     .addConstraintViolation();
 

--- a/src/main/java/com/dev/moim/global/validation/validator/LocalAccountValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/LocalAccountValidator.java
@@ -34,10 +34,8 @@ public class LocalAccountValidator implements ConstraintValidator<LocalAccountVa
         if (userQueryService.existsByEmail(email)) {
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate(EMAIL_DUPLICATION.getMessage())
-                    .addPropertyNode("email")
                     .addConstraintViolation();
 
-            log.warn("회원가입 실패 : 이메일 중복");
             return false;
         }
         return true;

--- a/src/main/java/com/dev/moim/global/validation/validator/MoimValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/MoimValidator.java
@@ -30,7 +30,6 @@ public class MoimValidator implements ConstraintValidator<MoimValidation, Long> 
         if (!isValidMoim) {
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate(MOIM_NOT_FOUND.getMessage())
-                    .addPropertyNode("moimId")
                     .addConstraintViolation();
             return false;
         }

--- a/src/main/java/com/dev/moim/global/validation/validator/MoimValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/MoimValidator.java
@@ -29,7 +29,7 @@ public class MoimValidator implements ConstraintValidator<MoimValidation, Long> 
 
         if (!isValidMoim) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(MOIM_NOT_FOUND.toString())
+            context.buildConstraintViolationWithTemplate(MOIM_NOT_FOUND.getMessage())
                     .addPropertyNode("moimId")
                     .addConstraintViolation();
             return false;

--- a/src/main/java/com/dev/moim/global/validation/validator/OAuthAccountValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/OAuthAccountValidator.java
@@ -25,42 +25,29 @@ public class OAuthAccountValidator implements ConstraintValidator<OAuthAccountVa
 
     @Override
     public boolean isValid(JoinRequest request, ConstraintValidatorContext context) {
+
         if (request.provider() == LOCAL) {
             return true;
         }
 
-        if (isProviderIdInvalid(request.providerId(), context)) {
-            log.warn("회원가입 실패 : providerId 누락");
+        String providerId = request.providerId();
+        if (providerId == null || providerId.isEmpty()) {
+            addConstraintViolation(context, PROVIDER_ID_NOT_FOUND.getMessage());
             return false;
         }
 
-        if (isProviderIdDuplicated(request, context)) {
-            log.warn("회원가입 실패 : 이미 가입된 소셜 계정");
+        boolean isDuplicated = userQueryService.existsByProviderAndProviderId(request.provider(), request.providerId());
+        if (isDuplicated) {
+            addConstraintViolation(context, OAUTH_ACCOUNT_DUPLICATION.getMessage());
             return false;
         }
 
         return true;
     }
 
-    private boolean isProviderIdInvalid(String providerId, ConstraintValidatorContext context) {
-        if (providerId == null || providerId.isEmpty()) {
-            context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(PROVIDER_ID_NOT_FOUND.getMessage())
-                    .addPropertyNode("providerId")
-                    .addConstraintViolation();
-            return true;
-        }
-        return false;
-    }
-
-    private boolean isProviderIdDuplicated(JoinRequest request, ConstraintValidatorContext context) {
-        boolean isDuplicated = userQueryService.existsByProviderAndProviderId(request.provider(), request.providerId());
-        if (isDuplicated) {
-            context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(OAUTH_ACCOUNT_DUPLICATION.getMessage())
-                    .addPropertyNode("providerId")
-                    .addConstraintViolation();
-        }
-        return isDuplicated;
+    private void addConstraintViolation(ConstraintValidatorContext context, String message) {
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate(message)
+                .addConstraintViolation();
     }
 }

--- a/src/main/java/com/dev/moim/global/validation/validator/OAuthAccountValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/OAuthAccountValidator.java
@@ -45,7 +45,7 @@ public class OAuthAccountValidator implements ConstraintValidator<OAuthAccountVa
     private boolean isProviderIdInvalid(String providerId, ConstraintValidatorContext context) {
         if (providerId == null || providerId.isEmpty()) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(PROVIDER_ID_NOT_FOUND.toString())
+            context.buildConstraintViolationWithTemplate(PROVIDER_ID_NOT_FOUND.getMessage())
                     .addPropertyNode("providerId")
                     .addConstraintViolation();
             return true;
@@ -57,7 +57,7 @@ public class OAuthAccountValidator implements ConstraintValidator<OAuthAccountVa
         boolean isDuplicated = userQueryService.existsByProviderAndProviderId(request.provider(), request.providerId());
         if (isDuplicated) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(OAUTH_ACCOUNT_DUPLICATION.toString())
+            context.buildConstraintViolationWithTemplate(OAUTH_ACCOUNT_DUPLICATION.getMessage())
                     .addPropertyNode("providerId")
                     .addConstraintViolation();
         }

--- a/src/main/java/com/dev/moim/global/validation/validator/PlanAuthorityValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/PlanAuthorityValidator.java
@@ -40,13 +40,13 @@ public class PlanAuthorityValidator implements ConstraintValidator<PlanAuthority
             if (userId.equals(writerId) || userId.equals(ownerId)) {
                 return true;
             }
-            addConstraintViolation(context, PLAN_EDIT_UNAUTHORIZED.toString(), "userId");
+            addConstraintViolation(context, PLAN_EDIT_UNAUTHORIZED.getMessage(), "userId");
             return false;
         } catch(PlanException e) {
-            addConstraintViolation(context, PLAN_NOT_FOUND.toString(), "planId");
+            addConstraintViolation(context, PLAN_NOT_FOUND.getMessage(), "planId");
             return false;
         } catch (MoimException e) {
-            addConstraintViolation(context, MOIM_OWNER_NOT_FOUND.toString(), "moimId");
+            addConstraintViolation(context, MOIM_OWNER_NOT_FOUND.getMessage(), "moimId");
             return false;
         }
     }

--- a/src/main/java/com/dev/moim/global/validation/validator/PlanAuthorityValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/PlanAuthorityValidator.java
@@ -40,21 +40,20 @@ public class PlanAuthorityValidator implements ConstraintValidator<PlanAuthority
             if (userId.equals(writerId) || userId.equals(ownerId)) {
                 return true;
             }
-            addConstraintViolation(context, PLAN_EDIT_UNAUTHORIZED.getMessage(), "userId");
+            addConstraintViolation(context, PLAN_EDIT_UNAUTHORIZED.getMessage());
             return false;
         } catch(PlanException e) {
-            addConstraintViolation(context, PLAN_NOT_FOUND.getMessage(), "planId");
+            addConstraintViolation(context, PLAN_NOT_FOUND.getMessage());
             return false;
         } catch (MoimException e) {
-            addConstraintViolation(context, MOIM_OWNER_NOT_FOUND.getMessage(), "moimId");
+            addConstraintViolation(context, MOIM_OWNER_NOT_FOUND.getMessage());
             return false;
         }
     }
 
-    private void addConstraintViolation(ConstraintValidatorContext context, String message, String propertyNode) {
+    private void addConstraintViolation(ConstraintValidatorContext context, String message) {
         context.disableDefaultConstraintViolation();
         context.buildConstraintViolationWithTemplate(message)
-                .addPropertyNode(propertyNode)
                 .addConstraintViolation();
     }
 }

--- a/src/main/java/com/dev/moim/global/validation/validator/PlanValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/PlanValidator.java
@@ -30,7 +30,6 @@ public class PlanValidator implements ConstraintValidator<PlanValidation, Long> 
         if (!isValidPlan) {
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate(PLAN_NOT_FOUND.getMessage())
-                    .addPropertyNode("planId")
                     .addConstraintViolation();
             return false;
         }

--- a/src/main/java/com/dev/moim/global/validation/validator/PlanValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/PlanValidator.java
@@ -29,7 +29,7 @@ public class PlanValidator implements ConstraintValidator<PlanValidation, Long> 
 
         if (!isValidPlan) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(PLAN_NOT_FOUND.toString())
+            context.buildConstraintViolationWithTemplate(PLAN_NOT_FOUND.getMessage())
                     .addPropertyNode("planId")
                     .addConstraintViolation();
             return false;

--- a/src/main/java/com/dev/moim/global/validation/validator/QuitValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/QuitValidator.java
@@ -30,8 +30,7 @@ public class QuitValidator implements ConstraintValidator<QuitValidation, User> 
 
         if (isMoimOwner) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(IS_MOIM_OWNER.toString())
-                    .addPropertyNode("user")
+            context.buildConstraintViolationWithTemplate(IS_MOIM_OWNER.getMessage())
                     .addConstraintViolation();
             return false;
         }

--- a/src/main/java/com/dev/moim/global/validation/validator/SelfReviewValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/SelfReviewValidator.java
@@ -36,12 +36,12 @@ public class SelfReviewValidator implements ConstraintValidator<SelfReviewValida
             Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
             if (targetUser.getId().toString().equals(authentication.getName())) {
-                addConstraintViolation(context, SELF_REVIEW_FORBIDDEN.toString());
+                addConstraintViolation(context, SELF_REVIEW_FORBIDDEN.getMessage());
                 return false;
             }
             return true;
         } catch (UserException e) {
-            addConstraintViolation(context, USER_NOT_FOUND.toString());
+            addConstraintViolation(context, USER_NOT_FOUND.getMessage());
             return false;
         }
     }
@@ -49,7 +49,6 @@ public class SelfReviewValidator implements ConstraintValidator<SelfReviewValida
     private void addConstraintViolation(ConstraintValidatorContext context, String message) {
         context.disableDefaultConstraintViolation();
         context.buildConstraintViolationWithTemplate(message)
-                .addPropertyNode("userId")
                 .addConstraintViolation();
     }
 }

--- a/src/main/java/com/dev/moim/global/validation/validator/TodoAssigneeValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/TodoAssigneeValidator.java
@@ -28,7 +28,7 @@ public class TodoAssigneeValidator implements ConstraintValidator<TodoAssigneeVa
 
         boolean isExistTodo = todoQueryService.existsByTodoId(todoId);
         if (!isExistTodo) {
-            addConstraintViolation(context, TODO_NOT_FOUND.toString());
+            addConstraintViolation(context, TODO_NOT_FOUND.getMessage());
             return false;
         }
 
@@ -36,7 +36,7 @@ public class TodoAssigneeValidator implements ConstraintValidator<TodoAssigneeVa
         boolean isAssignee = todoQueryService.existsByUserIdAndTodoId(Long.valueOf(authentication.getName()), todoId);
 
         if (!isAssignee) {
-            addConstraintViolation(context, NOT_TODO_ASSIGNEE.toString());
+            addConstraintViolation(context, NOT_TODO_ASSIGNEE.getMessage());
             return false;
         }
         return true;
@@ -45,7 +45,6 @@ public class TodoAssigneeValidator implements ConstraintValidator<TodoAssigneeVa
     private void addConstraintViolation(ConstraintValidatorContext context, String message) {
         context.disableDefaultConstraintViolation();
         context.buildConstraintViolationWithTemplate(message)
-                .addPropertyNode("todoId")
                 .addConstraintViolation();
     }
 }

--- a/src/main/java/com/dev/moim/global/validation/validator/TodoUpdateDueDateValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/TodoUpdateDueDateValidator.java
@@ -24,8 +24,6 @@ public class TodoUpdateDueDateValidator implements ConstraintValidator<TodoUpdat
     @Override
     public boolean isValid(LocalDate dueDate, ConstraintValidatorContext context) {
 
-        log.info("LocalDate.now() : {}", LocalDate.now());
-
         if (dueDate.isBefore(LocalDate.now())) {
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate(INVALID_TODO_DUE_DATE.getMessage())

--- a/src/main/java/com/dev/moim/global/validation/validator/TodoValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/TodoValidator.java
@@ -26,8 +26,7 @@ public class TodoValidator implements ConstraintValidator<TodoValidation, Long> 
 
         if (!isExistTodo) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(TODO_NOT_FOUND.toString())
-                    .addPropertyNode("todoId")
+            context.buildConstraintViolationWithTemplate(TODO_NOT_FOUND.getMessage())
                     .addConstraintViolation();
             return false;
         }

--- a/src/main/java/com/dev/moim/global/validation/validator/UpdatePasswordValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/UpdatePasswordValidator.java
@@ -25,8 +25,7 @@ public class UpdatePasswordValidator implements ConstraintValidator<UpdatePasswo
 
         if (password == null || !password.matches(passwordPattern)) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(INVALID_PASSWORD.toString())
-                    .addPropertyNode("password")
+            context.buildConstraintViolationWithTemplate(INVALID_PASSWORD.getMessage())
                     .addConstraintViolation();
             return false;
         }

--- a/src/main/java/com/dev/moim/global/validation/validator/UserMoimListValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/UserMoimListValidator.java
@@ -43,7 +43,6 @@ public class UserMoimListValidator implements ConstraintValidator<UserMoimListVa
         if (!isValidMember) {
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate(INVALID_MOIM_MEMBER.getMessage())
-                    .addPropertyNode("moimId")
                     .addConstraintViolation();
             return false;
         }

--- a/src/main/java/com/dev/moim/global/validation/validator/UserMoimValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/UserMoimValidator.java
@@ -32,22 +32,21 @@ public class UserMoimValidator implements ConstraintValidator<UserMoimValidaton,
 
         boolean isValidMoim = moimQueryService.existsByMoimId(moimId);
         if (!isValidMoim) {
-            addConstraintViolation(context, MOIM_NOT_FOUND.toString(), "moimId");
+            addConstraintViolation(context, MOIM_NOT_FOUND.getMessage());
             return false;
         }
 
         boolean isValidMember = moimQueryService.existsByUserIdAndMoimIdAndJoinStatus(Long.valueOf(authentication.getName()), moimId, COMPLETE);
         if (!isValidMember) {
-            addConstraintViolation(context, INVALID_MOIM_MEMBER.toString(), "userId");
+            addConstraintViolation(context, INVALID_MOIM_MEMBER.getMessage());
             return false;
         }
         return true;
     }
 
-    private void addConstraintViolation(ConstraintValidatorContext context, String message, String propertyNode) {
+    private void addConstraintViolation(ConstraintValidatorContext context, String message) {
         context.disableDefaultConstraintViolation();
         context.buildConstraintViolationWithTemplate(message)
-                .addPropertyNode(propertyNode)
                 .addConstraintViolation();
     }
 }

--- a/src/main/java/com/dev/moim/global/validation/validator/UserPlanDuplicateValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/UserPlanDuplicateValidator.java
@@ -30,7 +30,7 @@ public class UserPlanDuplicateValidator implements ConstraintValidator<UserPlanD
 
         boolean isValidPlan = calenderQueryService.existsByPlanId(planId);
         if (!isValidPlan) {
-            addConstraintViolation(context, PLAN_NOT_FOUND.toString());
+            addConstraintViolation(context, PLAN_NOT_FOUND.getMessage());
             return false;
         }
 
@@ -39,7 +39,7 @@ public class UserPlanDuplicateValidator implements ConstraintValidator<UserPlanD
         boolean alreadyParticipate = calenderQueryService.existsByUserIdAndPlanId(
                 Long.valueOf(authentication.getName()), planId);
         if (alreadyParticipate) {
-            addConstraintViolation(context, ALREADY_PARTICIPATE_IN_PLAN.toString());
+            addConstraintViolation(context, ALREADY_PARTICIPATE_IN_PLAN.getMessage());
             return false;
         }
         return true;
@@ -48,7 +48,6 @@ public class UserPlanDuplicateValidator implements ConstraintValidator<UserPlanD
     private void addConstraintViolation(ConstraintValidatorContext context, String message) {
         context.disableDefaultConstraintViolation();
         context.buildConstraintViolationWithTemplate(message)
-                .addPropertyNode("planId")
                 .addConstraintViolation();
     }
 }

--- a/src/main/java/com/dev/moim/global/validation/validator/UserPlanValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/UserPlanValidator.java
@@ -30,25 +30,24 @@ public class UserPlanValidator implements ConstraintValidator<UserPlanValidation
 
         boolean isValidPlan = calenderQueryService.existsByPlanId(planId);
         if (!isValidPlan) {
-            addConstraintViolation(context, PLAN_NOT_FOUND.toString(), "planId");
+            addConstraintViolation(context, PLAN_NOT_FOUND.getMessage());
             return false;
         }
 
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        Boolean isExistUserPlan = calenderQueryService.existsByUserIdAndPlanId(Long.valueOf(authentication.getName()), planId);
+        boolean isExistUserPlan = calenderQueryService.existsByUserIdAndPlanId(Long.valueOf(authentication.getName()), planId);
         if (!isExistUserPlan) {
-            addConstraintViolation(context, USER_NOT_PART_OF_PLAN.toString(), "userId");
+            addConstraintViolation(context, USER_NOT_PART_OF_PLAN.getMessage());
             return false;
         }
 
         return true;
     }
 
-    private void addConstraintViolation(ConstraintValidatorContext context, String message, String propertyNode) {
+    private void addConstraintViolation(ConstraintValidatorContext context, String message) {
         context.disableDefaultConstraintViolation();
         context.buildConstraintViolationWithTemplate(message)
-                .addPropertyNode(propertyNode)
                 .addConstraintViolation();
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #297 

## 📌 개요
- DTO에 적용한 커스텀 어노테이션에 의해서 예외가 발생할 경우 exceptionAdvice의 handleMethodArgumentNotValid에 의해서 응답이 생성됩니다. 이때 request body에서 여러 필드가 잘못된 경우가 있기 때문에 COMMON400 _BAD_REQUEST로 응답의 code, message를 설정해서 응답을 보냈었는데, 더 상세한 처리를 위해 하나의 필드가 잘못된 경우 해당 에러로 code, message를 설정하고, 여러 필드가 잘못된 경우 이를 나타내는 에러 code, message로 설정하고 응답을 보내도록 수정했습니다.
- handleMethodArgumentNotValid에 의해서 처리되면서 응답이 생성되는 과정에서, errorStatus를 .getMessage로 보낼 경우 해당하는 errorStatus를 찾지 못해 다시 에러를 발생시키고, 최종적으로 JwtAuthenticationEntryPoint에서 걸리게 되면서, 유저 인증에 실패했다는 응답이 나갔었습니다. 따라서 기존엔 .toString으로 보내도록 처리했었는데, validator에서 .getMessage를 보내면서, exceptionAdvice에서 이에 해당하는 errorStatus를 찾도록 수정했습니다.

## 🔁 변경 사항
✔️ 074c091b1a113b745b3d2de5f27c9b0faebcc2b4 : individualPlanValidator 로직 수정
✔️ 21d13f9f14a83b83ecf54e7fd6b4f6192052b4af : MethodArgumentNotValidException 응답 처리
✔️ a03e9d6c8e6de82111a80365888e0d75199f5410 : todo assignee 검증 어노테이션 적용
✔️ 1197ea94c4528678d3864f2a9f76b9a13d497d4c : 에러 메세지 정리
✔️ 4575d76e032b7c9fec24cdf4a2b6ff718552623a : validation 정리

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
