### PR TITLE
✨ Feature: todo, 일정 관련 스케줄러 기능 구현

### DIFF
--- a/src/main/java/com/dev/moim/MoimApplication.java
+++ b/src/main/java/com/dev/moim/MoimApplication.java
@@ -6,7 +6,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableConfigurationProperties(OauthProperties.class)
 @EnableJpaAuditing
 @EnableFeignClients

--- a/src/main/java/com/dev/moim/domain/account/repository/UserRepository.java
+++ b/src/main/java/com/dev/moim/domain/account/repository/UserRepository.java
@@ -67,4 +67,6 @@ public interface UserRepository extends JpaRepository<User, Long>, CustomUserRep
     @Modifying
     @Query("update User u set u.lastAlarmTime = :lastReadTime where u = :user")
     void updateLastReadTime(User user, LocalDateTime lastReadTime);
+
+    List<User> findAllByIsPushAlarmTrueAndDeviceIdNotNull();
 }

--- a/src/main/java/com/dev/moim/domain/moim/repository/TodoRepository.java
+++ b/src/main/java/com/dev/moim/domain/moim/repository/TodoRepository.java
@@ -1,10 +1,14 @@
 package com.dev.moim.domain.moim.repository;
 
 import com.dev.moim.domain.moim.entity.Todo;
+import com.dev.moim.domain.moim.entity.enums.TodoStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface TodoRepository extends JpaRepository<Todo, Long> {
 
@@ -18,4 +22,6 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
 
     @Query("SELECT t FROM Todo t WHERE t.writer.id = :writerId AND t.id < :cursor ORDER BY t.id DESC")
     Slice<Todo> findByWriterIdAndCursorLessThan(Long writerId, Long cursor, Pageable pageable);
+
+    List<Todo> findAllByStatusAndDueDateBefore(TodoStatus todoStatus, LocalDateTime now);
 }

--- a/src/main/java/com/dev/moim/domain/moim/repository/TodoRepository.java
+++ b/src/main/java/com/dev/moim/domain/moim/repository/TodoRepository.java
@@ -24,4 +24,6 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
     Slice<Todo> findByWriterIdAndCursorLessThan(Long writerId, Long cursor, Pageable pageable);
 
     List<Todo> findAllByStatusAndDueDateBefore(TodoStatus todoStatus, LocalDateTime now);
+
+    List<Todo> findAllByDueDateBetween(LocalDateTime tomorrow, LocalDateTime endOfTomorrow);
 }

--- a/src/main/java/com/dev/moim/domain/moim/repository/UserTodoRepository.java
+++ b/src/main/java/com/dev/moim/domain/moim/repository/UserTodoRepository.java
@@ -2,6 +2,7 @@ package com.dev.moim.domain.moim.repository;
 
 import com.dev.moim.domain.account.entity.User;
 import com.dev.moim.domain.moim.entity.UserTodo;
+import com.dev.moim.domain.moim.entity.enums.TodoAssigneeStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -51,4 +52,6 @@ public interface UserTodoRepository extends JpaRepository<UserTodo, Long> {
             @Param("userId") Long userId,
             @Param("startDate") LocalDateTime startDate,
             @Param("endDate") LocalDateTime endDate);
+
+    List<UserTodo> findAllByTodoIdAndStatusNot(Long todoId, TodoAssigneeStatus todoAssigneeStatus);
 }

--- a/src/main/java/com/dev/moim/domain/moim/service/TodoCommandService.java
+++ b/src/main/java/com/dev/moim/domain/moim/service/TodoCommandService.java
@@ -16,4 +16,6 @@ public interface TodoCommandService {
     void addAssignees(User user, AddTodoAssigneeDTO request);
 
     void deleteAssignees(DeleteTodoAssigneeDTO request);
+
+    void updateExpiredTodosAndAssigneesStatus();
 }

--- a/src/main/java/com/dev/moim/domain/moim/service/impl/TodoCommandServiceImpl.java
+++ b/src/main/java/com/dev/moim/domain/moim/service/impl/TodoCommandServiceImpl.java
@@ -207,4 +207,17 @@ public class TodoCommandServiceImpl implements TodoCommandService {
 
         todo.getUserTodoList().removeAll(userTodoList);
     }
+
+    @Override
+    public void updateExpiredTodosAndAssigneesStatus() {
+
+        List<Todo> expiredTodoList = todoRepository.findAllByStatusAndDueDateBefore(TodoStatus.IN_PROGRESS, LocalDateTime.now());
+
+        expiredTodoList.forEach(todo -> {
+            List<UserTodo> incompleteUserTodoList = userTodoRepository.findAllByTodoIdAndStatusNot(todo.getId(), TodoAssigneeStatus.COMPLETE);
+            incompleteUserTodoList.forEach(userTodo -> userTodo.updateStatus(TodoAssigneeStatus.OVERDUE));
+
+            todo.updateStatus(TodoStatus.EXPIRED);
+        });
+    }
 }

--- a/src/main/java/com/dev/moim/global/scheduler/PlanScheduler.java
+++ b/src/main/java/com/dev/moim/global/scheduler/PlanScheduler.java
@@ -1,0 +1,57 @@
+package com.dev.moim.global.scheduler;
+
+import com.dev.moim.domain.account.entity.User;
+import com.dev.moim.domain.account.entity.enums.AlarmDetailType;
+import com.dev.moim.domain.account.entity.enums.AlarmType;
+import com.dev.moim.domain.account.repository.UserRepository;
+import com.dev.moim.domain.account.service.AlarmService;
+import com.dev.moim.domain.moim.repository.IndividualPlanRepository;
+import com.dev.moim.domain.moim.repository.UserPlanRepository;
+import com.dev.moim.domain.moim.repository.UserTodoRepository;
+import com.dev.moim.global.firebase.service.FcmService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class PlanScheduler {
+
+    private final IndividualPlanRepository individualPlanRepository;
+    private final UserPlanRepository userPlanRepository;
+    private final UserTodoRepository userTodoRepository;
+    private final UserRepository userRepository;
+    private final AlarmService alarmService;
+    private final FcmService fcmService;
+
+    @Scheduled(cron = "0 0 9 * * *")
+    public void notifyDailyPlanCnt() {
+
+        List<User> userList = userRepository.findAllByIsPushAlarmTrueAndDeviceIdNotNull();
+
+        userList.forEach(user -> {
+            LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+            LocalDateTime endOfDay = LocalDate.now().atTime(23, 59, 59, 999999000);;
+
+            int individualPlanCnt = individualPlanRepository.countByUserAndDateBetween(user, startOfDay, endOfDay);
+            int moimPlanCnt = userPlanRepository.countPlansByUserAndDateBetween(user, startOfDay, endOfDay);
+            int todoPlanCnt = userTodoRepository.countByUserAndTodoDueDateBetween(user, startOfDay, endOfDay);
+
+            String content = String.format(
+                    "개인 일정: %d, 모임 일정: %d, 오늘 마감인 할 일: %d",
+                    individualPlanCnt, moimPlanCnt, todoPlanCnt
+            );
+
+            alarmService.saveAlarm(user, user, "오늘 예정된 일정", content, AlarmType.PUSH, AlarmDetailType.PLAN, null, null, null);
+            fcmService.sendNotification(user, "오늘 예정된 일정", content);
+        });
+    }
+}

--- a/src/main/java/com/dev/moim/global/scheduler/TodoScheduler.java
+++ b/src/main/java/com/dev/moim/global/scheduler/TodoScheduler.java
@@ -1,11 +1,24 @@
 package com.dev.moim.global.scheduler;
 
+import com.dev.moim.domain.account.entity.User;
+import com.dev.moim.domain.account.entity.enums.AlarmDetailType;
+import com.dev.moim.domain.account.entity.enums.AlarmType;
+import com.dev.moim.domain.account.service.AlarmService;
+import com.dev.moim.domain.moim.entity.Todo;
+import com.dev.moim.domain.moim.entity.UserTodo;
+import com.dev.moim.domain.moim.entity.enums.TodoAssigneeStatus;
+import com.dev.moim.domain.moim.repository.TodoRepository;
+import com.dev.moim.domain.moim.repository.UserTodoRepository;
 import com.dev.moim.domain.moim.service.TodoCommandService;
+import com.dev.moim.global.firebase.service.FcmService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -14,9 +27,36 @@ import org.springframework.transaction.annotation.Transactional;
 public class TodoScheduler {
 
     private final TodoCommandService todoCommandService;
+    private final TodoRepository todoRepository;
+    private final UserTodoRepository userTodoRepository;
+    private final AlarmService alarmService;
+    private final FcmService fcmService;
 
     @Scheduled(cron = "0 0 0 * * *")
     public void updateTodosToExpiredStatus() {
         todoCommandService.updateExpiredTodosAndAssigneesStatus();
+    }
+
+    @Scheduled(cron = "0 0 16 * * *")
+    public void notifyDueTodos() {
+
+        LocalDateTime tomorrow = LocalDateTime.now().plusDays(1).withHour(0).withMinute(0).withSecond(0).withNano(0);
+        LocalDateTime endOfTomorrow = tomorrow.withHour(23).withMinute(59).withSecond(59).withNano(999999999);
+
+        List<Todo> dueTomorrowTodoList = todoRepository.findAllByDueDateBetween(tomorrow, endOfTomorrow);
+
+        dueTomorrowTodoList.forEach(todo -> {
+            List<UserTodo> userTodoList = userTodoRepository.findAllByTodoIdAndStatusNot(todo.getId(), TodoAssigneeStatus.COMPLETE);
+
+            userTodoList.forEach(userTodo -> {
+                User assignee = userTodo.getUser();
+
+                alarmService.saveAlarm(todo.getWriter(), assignee, "마감 기한이 하루 남았습니다.", todo.getTitle(), AlarmType.PUSH, AlarmDetailType.TODO, todo.getMoim().getId(), null, null);
+
+                if (assignee.getIsPushAlarm() && assignee.getDeviceId() != null) {
+                    fcmService.sendNotification(assignee, "마감 기한이 하루 남았습니다.", todo.getTitle());
+                }
+            });
+        });
     }
 }

--- a/src/main/java/com/dev/moim/global/scheduler/TodoScheduler.java
+++ b/src/main/java/com/dev/moim/global/scheduler/TodoScheduler.java
@@ -1,0 +1,22 @@
+package com.dev.moim.global.scheduler;
+
+import com.dev.moim.domain.moim.service.TodoCommandService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class TodoScheduler {
+
+    private final TodoCommandService todoCommandService;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void updateTodosToExpiredStatus() {
+        todoCommandService.updateExpiredTodosAndAssigneesStatus();
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #307 

## 📌 개요
- 일정 관련 스케줄러 기능 구현

## 🔁 변경 사항
✔️ 20eafb053bca217a0e44face02cdcb001cd42ab0 : 매일 자정 마감기한 지난 미완료 todo 상태 EXPIRED로 변경
✔️ 84961565464b6da785db02d74a34d3f9e29a3ba2 : 매일 오후 마감기한 하루 남은 투두 알림 전송
- 매일 오후, 마감 기한이 하루 남은 todo를 완료하지 않은 유저에게 알림 전송

✔️ f8c1dcc618858fee436a38745cd82d779febaabb : 매일 오전 유저의 예정된 일정 개수 알림 전송
- 매일 오전, 유저에게 예정된 일정 (개인 일정 + 참여 신청한 모임의 일정 + 투두) 개수 공지 알림 전송


## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
