### PR TITLE
✨ Feature: 포그라운드 상태에서도 푸시 알림 표시할 수 있도록 처리

### DIFF
--- a/src/main/java/com/dev/moim/domain/moim/service/impl/CalenderCommandServiceImpl.java
+++ b/src/main/java/com/dev/moim/domain/moim/service/impl/CalenderCommandServiceImpl.java
@@ -93,7 +93,7 @@ public class CalenderCommandServiceImpl implements CalenderCommandService {
                     alarmService.saveAlarm(user, planUser, "[" + plan.getMoim().getName() + "]" + plan.getTitle(), userProfile.getName() + " 님이 참여 신청했습니다", AlarmType.PUSH, AlarmDetailType.PLAN, plan.getMoim().getId(), null, null);
 
                     if (planUser.getIsPushAlarm() && planUser.getDeviceId() != null) {
-                        fcmService.sendNotification(planUser, "[" + plan.getMoim().getName() + "]" + plan.getTitle(), userProfile.getName() + " 님이 참여 신청했습니다");
+                        fcmService.sendPushNotification(planUser, "[" + plan.getMoim().getName() + "]" + plan.getTitle(), userProfile.getName() + " 님이 참여 신청했습니다", AlarmDetailType.PLAN);
                     }
                 });
 
@@ -138,7 +138,7 @@ public class CalenderCommandServiceImpl implements CalenderCommandService {
             alarmService.saveAlarm(plan.getUser(), participant, "[" + plan.getMoim().getName() + "]" + plan.getTitle(), "일정이 수정되었습니다. 변경사항을 확인해주세요.", AlarmType.PUSH, AlarmDetailType.PLAN, plan.getMoim().getId(), null, null);
 
             if (participant.getIsPushAlarm() && participant.getDeviceId() != null) {
-                fcmService.sendNotification(participant, "[" + plan.getMoim().getName() + "]" + plan.getTitle(), "일정이 수정되었습니다. 변경사항을 확인해주세요.");
+                fcmService.sendPushNotification(participant, "[" + plan.getMoim().getName() + "]" + plan.getTitle(), "일정이 수정되었습니다. 변경사항을 확인해주세요.", AlarmDetailType.PLAN);
             }
 
         });
@@ -158,7 +158,7 @@ public class CalenderCommandServiceImpl implements CalenderCommandService {
             alarmService.saveAlarm(plan.getUser(), participant, "[" + plan.getMoim().getName() + "]" + plan.getTitle(), "일정이 취소되었습니다.", AlarmType.PUSH, AlarmDetailType.PLAN, plan.getMoim().getId(), null, null);
 
             if (participant.getIsPushAlarm() && participant.getDeviceId() != null) {
-                fcmService.sendNotification(participant, "[" + plan.getMoim().getName() + "]" + plan.getTitle(), "일정이 취소되었습니다.");
+                fcmService.sendPushNotification(participant, "[" + plan.getMoim().getName() + "]" + plan.getTitle(), "일정이 취소되었습니다.", AlarmDetailType.PLAN);
             }
         });
 

--- a/src/main/java/com/dev/moim/domain/moim/service/impl/TodoCommandServiceImpl.java
+++ b/src/main/java/com/dev/moim/domain/moim/service/impl/TodoCommandServiceImpl.java
@@ -85,7 +85,7 @@ public class TodoCommandServiceImpl implements TodoCommandService {
                     alarmService.saveAlarm(user, assignee, "새로운 할 일이 도착했습니다", todo.getTitle(), AlarmType.PUSH, AlarmDetailType.TODO, moim.getId(), null, null);
 
                     if (assignee.getIsPushAlarm() && assignee.getDeviceId() != null) {
-                        fcmService.sendAndroidNotification(assignee, "새로운 할 일이 도착했습니다", todo.getTitle(), AlarmDetailType.TODO);
+                        fcmService.sendPushNotification(assignee, "새로운 할 일이 도착했습니다", todo.getTitle(), AlarmDetailType.TODO);
                     }
                 });
 
@@ -157,7 +157,7 @@ public class TodoCommandServiceImpl implements TodoCommandService {
                     alarmService.saveAlarm(user, assignee, "할 일이 수정되었습니다", todo.getTitle(), AlarmType.PUSH, AlarmDetailType.TODO, moimId, null, null);
 
                     if (assignee.getIsPushAlarm() && assignee.getDeviceId() != null) {
-                        fcmService.sendNotification(assignee, "할 일이 수정되었습니다", todo.getTitle());
+                        fcmService.sendPushNotification(assignee, "할 일이 수정되었습니다", todo.getTitle(), AlarmDetailType.TODO);
                     }
                 });
     }
@@ -190,7 +190,7 @@ public class TodoCommandServiceImpl implements TodoCommandService {
                     alarmService.saveAlarm(user, assignee, "새로운 할 일이 도착했습니다", todo.getTitle(), AlarmType.PUSH, AlarmDetailType.TODO, request.moimId(), null, null);
 
                     if (assignee.getIsPushAlarm() && assignee.getDeviceId() != null) {
-                        fcmService.sendNotification(assignee, "새로운 할 일이 도착했습니다", todo.getTitle());
+                        fcmService.sendPushNotification(assignee, "새로운 할 일이 도착했습니다", todo.getTitle(), AlarmDetailType.TODO);
                     }
                 });
     }

--- a/src/main/java/com/dev/moim/global/firebase/service/FcmService.java
+++ b/src/main/java/com/dev/moim/global/firebase/service/FcmService.java
@@ -65,15 +65,13 @@ public class FcmService {
         }
     }
 
-    public void sendAndroidNotification(User receiver, String title, String body, AlarmDetailType alarmDetailType) {
+    public void sendPushNotification(User receiver, String title, String body, AlarmDetailType alarmDetailType) {
 
         if (!(receiver.getDeviceId() == null)) {
             Notification notification = Notification.builder()
                     .setTitle(title)
                     .setBody(body)
                     .build();
-
-            Integer count = userQueryService.countAlarm(receiver);
 
             AndroidNotification androidNotification = AndroidNotification.builder()
                     .setChannelId(alarmDetailType.toString())
@@ -83,10 +81,21 @@ public class FcmService {
                     .setNotification(androidNotification)
                     .build();
 
+            ApnsFcmOptions apnsFcmOptions = ApnsFcmOptions.builder()
+                    .setAnalyticsLabel(alarmDetailType.toString())
+                    .build();
+
+            ApnsConfig apnsConfig = ApnsConfig.builder()
+                    .setFcmOptions(apnsFcmOptions)
+                    .build();
+
+            Integer count = userQueryService.countAlarm(receiver);
+
             Message message = Message.builder()
+                    .setNotification(notification)
                     .setToken(receiver.getDeviceId())
                     .setAndroidConfig(androidConfig)
-                    .setNotification(notification)
+                    .setApnsConfig(apnsConfig)
                     .putData("count", count.toString())
                     .build();
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #318 

## 📌 개요
- 포그라운드 상태에서도 푸시 알림 표시할 수 있도록 처리

## 🔁 변경 사항
✔️ 1e145cf1fe0b5454963e2441d22af3be13483cac : 포그라운드 상태에서도 푸시 알림 표시할 수 있도록 처리
- 포그라운드 상태에서도 푸시 알림을 표시할 수 있도록 처리할 수 있게 하기 위해 푸시 알림 설정을 할 때 추가적인 설정을 해줬습니다. 안드로이드에서 설정을 위해 AndroidNotification, AndroidConfig를 추가했었고, ios에서 설정을 위해 ApnsFcmOptions, ApnsConfig 설정을 추가했습니다.
- ApnsFcmOptions, ApnsConfig 설정 추가
- todo, plan 로직에 적용 (sendPushNotification)

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
