### PR TITLE
✨ Feature: 참여 신청한 모임 일정 조회 DTO에 유저의 moimRole 필드 추가

### DIFF
--- a/src/main/java/com/dev/moim/domain/user/dto/UserDailyPlanPageDTO.java
+++ b/src/main/java/com/dev/moim/domain/user/dto/UserDailyPlanPageDTO.java
@@ -15,15 +15,11 @@ public record UserDailyPlanPageDTO(
         Boolean hasNext,
         List<UserPlanDTO> userPlanDTOList
 ) {
-    public static UserDailyPlanPageDTO toUserMoimPlan(Slice<Plan> userMoimPlanSlice) {
-        List<UserPlanDTO> userMoimPlanDTOList = userMoimPlanSlice.stream()
-                .map(UserPlanDTO::toUserMoimPlan)
-                .toList();
-
+    public static UserDailyPlanPageDTO toUserMoimPlan(Slice<Plan> userMoimPlanSlice, List<UserPlanDTO> userPlanDTOList) {
         return new UserDailyPlanPageDTO(
                 userMoimPlanSlice.isFirst(),
                 userMoimPlanSlice.hasNext(),
-                userMoimPlanDTOList
+                userPlanDTOList
         );
     }
 

--- a/src/main/java/com/dev/moim/domain/user/dto/UserPlanDTO.java
+++ b/src/main/java/com/dev/moim/domain/user/dto/UserPlanDTO.java
@@ -3,6 +3,8 @@ package com.dev.moim.domain.user.dto;
 import com.dev.moim.domain.moim.entity.IndividualPlan;
 import com.dev.moim.domain.moim.entity.Plan;
 import com.dev.moim.domain.moim.entity.Todo;
+import com.dev.moim.domain.moim.entity.UserMoim;
+import com.dev.moim.domain.moim.entity.enums.MoimRole;
 import com.dev.moim.domain.moim.entity.enums.PlanType;
 
 import java.time.LocalDateTime;
@@ -18,7 +20,8 @@ public record UserPlanDTO(
         String memo,
         Long moimId,
         String moimName,
-        PlanType planType
+        PlanType planType,
+        MoimRole moimRole
 ) {
     public static UserPlanDTO toIndividualPlan(IndividualPlan individualPlan) {
         return new UserPlanDTO(
@@ -30,11 +33,12 @@ public record UserPlanDTO(
                 individualPlan.getMemo(),
                 null,
                 null,
-                INDIVIDUAL_PLAN
+                INDIVIDUAL_PLAN,
+                null
         );
     }
 
-    public static UserPlanDTO toUserMoimPlan(Plan plan) {
+    public static UserPlanDTO toUserMoimPlan(Plan plan, UserMoim userMoim) {
         return new UserPlanDTO(
                 plan.getId(),
                 plan.getTitle(),
@@ -44,7 +48,8 @@ public record UserPlanDTO(
                 null,
                 plan.getMoim().getId(),
                 plan.getMoim().getName(),
-                MOIM_PLAN
+                MOIM_PLAN,
+                userMoim.getMoimRole()
         );
     }
 
@@ -58,7 +63,8 @@ public record UserPlanDTO(
                 null,
                 todo.getMoim().getId(),
                 todo.getMoim().getName(),
-                TODO_PLAN
+                TODO_PLAN,
+                null
         );
     }
 
@@ -80,7 +86,8 @@ public record UserPlanDTO(
                 memo,
                 moimId,
                 moimName,
-                planType
+                planType,
+                null
         );
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #341 

## 📌 개요
- 특정 월에 유저의 모든 일정을 조회할 때, 해당 일정이 유저가 참여 신청한 모임 일정인 경우, 유저의 moimRole에 따라 해당 일정의 수정, 삭제 권한이 달라지므로 이를 구분하기 위해 해당 유저의 moimRole 필드를 추가하게 되었습니다.

## 🔁 변경 사항
✔️ d9a61216fc1a7cc0d85628d9ffcd12f7fbb4d216 : 참여 신청한 모임 일정 조회 DTO에 유저의 moimRole 필드 추가

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
