### PR TITLE
✨ Feature: 모임장 제외 모임 멤버 조회 기능 구현

### DIFF
--- a/src/main/java/com/dev/moim/domain/account/repository/UserRepository.java
+++ b/src/main/java/com/dev/moim/domain/account/repository/UserRepository.java
@@ -69,4 +69,15 @@ public interface UserRepository extends JpaRepository<User, Long>, CustomUserRep
     void updateLastReadTime(User user, LocalDateTime lastReadTime);
 
     List<User> findAllByIsPushAlarmTrueAndDeviceIdNotNull();
+
+    @Query("select new com.dev.moim.domain.moim.service.impl.dto.UserProfileDTO(up, um) " +
+            "from UserMoim um " +
+            "join um.userProfile up " +
+            "where um.moim.id = :moimId " +
+            "and um.joinStatus = :joinStatus " +
+            "and um.moimRole <> 'OWNER' " +
+            "and um.id > :cursor " +
+            "and up.name like %:searching% " +
+            "order by um.id")
+    Slice<UserProfileDTO> findUserByMoimIdExcludeOwner(Long moimId, String searching, JoinStatus joinStatus, Long cursor, Pageable pageable);
 }

--- a/src/main/java/com/dev/moim/domain/moim/controller/MoimController.java
+++ b/src/main/java/com/dev/moim/domain/moim/controller/MoimController.java
@@ -165,6 +165,21 @@ public class MoimController {
         return BaseResponse.onSuccess(userPreviewListDTO);
     }
 
+    @Operation(summary = "모임 멤버 API (모임장 제외)", description = "모임장을 제외한 모임 멤버들을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+    })
+    @GetMapping("/moims/{moimId}/members/owner")
+    public BaseResponse<UserPreviewListDTO> getMoimMembersExcludeOwner(
+            @AuthUser User user,
+            @CheckOwnerValidation @UserMoimValidaton @PathVariable Long moimId,
+            @CheckCursorValidation @RequestParam(name = "cursor") Long cursor,
+            @CheckTakeValidation @RequestParam(name = "take") Integer take,
+            @RequestParam(name = "search") String search) {
+        UserPreviewListDTO userPreviewListDTO = moimQueryService.getMoimMembersExcludeOwner(moimId, cursor, take, search);
+        return BaseResponse.onSuccess(userPreviewListDTO);
+    }
+
     @Operation(summary = "모임 탈퇴 하기 API", description = "모임을 탈퇴 합니다. _by 제이미_")
     @ApiResponses({
             @ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),

--- a/src/main/java/com/dev/moim/domain/moim/service/MoimQueryService.java
+++ b/src/main/java/com/dev/moim/domain/moim/service/MoimQueryService.java
@@ -22,6 +22,8 @@ public interface MoimQueryService {
 
     UserPreviewListDTO getMoimMembers(Long moimId, Long cursor, Integer take, String search);
 
+    UserPreviewListDTO getMoimMembersExcludeOwner(Long moimId, Long cursor, Integer take, String search);
+
     UserPreviewListDTO findRequestMember(User user, Long moimId, Long cursor, Integer take, String search);
 
     MoimIntroduceDTO getIntroduce(Long moimId);

--- a/src/main/java/com/dev/moim/domain/moim/service/impl/MoimQueryServiceImpl.java
+++ b/src/main/java/com/dev/moim/domain/moim/service/impl/MoimQueryServiceImpl.java
@@ -131,6 +131,21 @@ public class MoimQueryServiceImpl implements MoimQueryService {
     }
 
     @Override
+    public UserPreviewListDTO getMoimMembersExcludeOwner(Long moimId, Long cursor, Integer take, String search) {
+
+        Slice<UserProfileDTO> moimUsers = userRepository.findUserByMoimIdExcludeOwner(moimId, search, JoinStatus.COMPLETE, cursor, PageRequest.of(0, take));
+
+        List<UserPreviewDTO> userPreviewDTOList = moimUsers.toList().stream().map(UserPreviewDTO::toUserPreviewDTO).toList();
+
+        Long nextCursor = null;
+        if (!moimUsers.isLast()) {
+            nextCursor = moimUsers.toList().get(moimUsers.toList().size() - 1).getUserMoim().getId();
+        }
+
+        return UserPreviewListDTO.toUserPreviewListDTO(userPreviewDTOList, moimUsers.hasNext(), nextCursor);
+    }
+
+    @Override
     public UserPreviewListDTO findRequestMember(User user, Long moimId, Long cursor, Integer take, String search) {
 
 

--- a/src/main/java/com/dev/moim/global/validation/validator/CheckOwnerValidator.java
+++ b/src/main/java/com/dev/moim/global/validation/validator/CheckOwnerValidator.java
@@ -36,7 +36,7 @@ public class CheckOwnerValidator implements ConstraintValidator<CheckOwnerValida
 
         if (userMoim.isEmpty()) {
             context.disableDefaultConstraintViolation();
-            context.buildConstraintViolationWithTemplate(INVALID_MOIM_MEMBER.toString())
+            context.buildConstraintViolationWithTemplate(INVALID_MOIM_MEMBER.getMessage())
                     .addPropertyNode("userId")
                     .addPropertyNode("moimId")
                     .addConstraintViolation();
@@ -46,7 +46,7 @@ public class CheckOwnerValidator implements ConstraintValidator<CheckOwnerValida
                 return true;
             } else {
                 context.disableDefaultConstraintViolation();
-                context.buildConstraintViolationWithTemplate(MOIM_NOT_ADMIN.toString())
+                context.buildConstraintViolationWithTemplate(MOIM_NOT_ADMIN.getMessage())
                         .addPropertyNode("userId")
                         .addPropertyNode("moimId")
                         .addConstraintViolation();


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #347 

## 📌 개요
- 모임장 제외 모임 멤버 조회 기능 구현

## 🔁 변경 사항
✔️ 3a47207dd5607001cbc78d667031e84cb1a87649 : 모임장 제외 모임 멤버 조회 기능 구현
✔️ 00c9b7ddb28d78f73f1c49c06e6fcfbb8e0fa9c9 : 유효하지 않은 파라미터 값 여러 개인 경우 처리되도록 수정
- 파라미터에 유효하지 않은 값이 전달된 경우 ConstraintViolationException이 나가고, ExceptionAdvice에서 validation, handleExceptionInternalConstraint에 의해서 처리됩니다. CheckOwnerValidator에서 .toString()으로 전달했기 때문에, 기존엔 validation에서의 처리 로직 상 일치하는 errorStatus를 찾지 못하게되어 validation에서 IllegalArgumentException를 내게 되어 최종적으로 jJwtAuthenticationEntryPoint에서 에러를 처리하게 되면서 유저 인증에 실패했다는 에러로 에러 메세지가 나갔습니다. 따라서 .getMessage()를 전달하도록 수정했습니다.

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
