### PR TITLE
✨ Feature: 유저 엔티티 성별, 거주지, 생년월일 필드 null 허용

### DIFF
--- a/src/main/java/com/dev/moim/domain/account/dto/JoinRequest.java
+++ b/src/main/java/com/dev/moim/domain/account/dto/JoinRequest.java
@@ -7,6 +7,7 @@ import com.dev.moim.global.validation.annotation.LocalAccountValidation;
 import com.dev.moim.global.validation.annotation.JoinPasswordValidation;
 import com.dev.moim.global.validation.annotation.OAuthAccountValidation;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import org.springframework.lang.NonNull;
@@ -14,6 +15,7 @@ import org.springframework.lang.NonNull;
 import java.time.LocalDate;
 
 // @JoinFcmTokenValidtaion
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @OAuthAccountValidation
 @LocalAccountValidation
 @JoinPasswordValidation
@@ -28,12 +30,12 @@ public record JoinRequest(
         @NotBlank
         String email,
         String password,
-        @Schema(description = "성별", defaultValue = "FEMALE", allowableValues = {"FEMALE", "MALE"})
-        @NonNull
+        @Schema(description = "성별", defaultValue = "FEMALE", allowableValues = {"FEMALE", "MALE"}, nullable = true)
         Gender gender,
+        @Schema(nullable = true)
         @JsonFormat(pattern = "yyyy-MM-dd")
         LocalDate birth,
-        @NotBlank
+        @Schema(nullable = true)
         String residence
 ) {
 }

--- a/src/main/java/com/dev/moim/domain/account/entity/User.java
+++ b/src/main/java/com/dev/moim/domain/account/entity/User.java
@@ -54,14 +54,10 @@ public class User extends BaseEntity {
     private Boolean isEventAlarm;
 
     @Enumerated(EnumType.STRING)
-    @ColumnDefault("'FEMALE'")
-    @Column(nullable = false)
     private Gender gender;
 
-    @Column(nullable = false)
     private LocalDate birth;
 
-    @Column(nullable = false)
     private String residence;
 
     private double rating;

--- a/src/main/java/com/dev/moim/domain/account/entity/enums/Gender.java
+++ b/src/main/java/com/dev/moim/domain/account/entity/enums/Gender.java
@@ -1,13 +1,19 @@
 package com.dev.moim.domain.account.entity.enums;
 
 import com.dev.moim.global.error.GeneralException;
+import com.fasterxml.jackson.annotation.JsonCreator;
 
 import static com.dev.moim.global.common.code.status.ErrorStatus.INVALID_GENDER;
 
 public enum Gender {
     MALE, FEMALE;
 
+    @JsonCreator
     public static Gender from(String gender) {
+        if (gender == null || gender.isEmpty()) {
+            return null;
+        }
+
         try {
             return Gender.valueOf(gender.toUpperCase());
         } catch (GeneralException e) {

--- a/src/main/java/com/dev/moim/domain/user/dto/UpdateUserDefaultInfoDTO.java
+++ b/src/main/java/com/dev/moim/domain/user/dto/UpdateUserDefaultInfoDTO.java
@@ -1,12 +1,11 @@
 package com.dev.moim.domain.user.dto;
 
 import com.dev.moim.domain.account.entity.enums.Gender;
-import jakarta.validation.constraints.NotBlank;
 
 import java.time.LocalDate;
 
 public record UpdateUserDefaultInfoDTO(
-        @NotBlank String residence,
+        String residence,
         Gender gender,
         LocalDate birth
 ) {

--- a/src/main/java/com/dev/moim/domain/user/dto/UpdateUserInfoDTO.java
+++ b/src/main/java/com/dev/moim/domain/user/dto/UpdateUserInfoDTO.java
@@ -9,7 +9,7 @@ import java.util.List;
 public record UpdateUserInfoDTO(
         @NotBlank String nickname,
         String imageKey,
-        @NotBlank String residence,
+        String residence,
         String introduction,
         @Schema(description = "프로필에 공개할 모임 ID 리스트")
         @UserMoimListValidation List<Long> publicMoimList


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #374 

## 📌 개요
- 배포 과정에서 특정 유저 정보 (성별, 거주지, 생년월일) 의 경우 개인 정보 보호 규정에 의해 선택 사항으로 두게되어 해당 정보들을 null을 허용하도록 변경합니다

## 🔁 변경 사항
✔️ bfa9646e57ba6f94eb1b3504bb08e343d2e83016 : 유저 엔티티 성별, 거주지, 생년월일 필드 null 허용

유저 엔티티 성별, 거주지, 생년월일 필드 null 허용
- Gender enum에 적용
- 회원가입 로직에서 반영
- (멀티 프로필 적용 전 ver) 유저 정보 수정 DTO에 반영
- (멀티 프로필 적용 후 ver) 유저 기본 정보 수정 DTO에 반영

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
